### PR TITLE
Remove assumptions about preprocessor_next

### DIFF
--- a/model-checking/scheduler.als
+++ b/model-checking/scheduler.als
@@ -36,9 +36,24 @@ sig Command {
         partialOrder[~dependency]
 
         //The preprocessor does not create a cycle with the actual dependencies
-        no (^preprocessor_next).(^~dependency)
        
+       all c : Command {
+         (not preprocSame[c]) iff { 
+            // The command find dependencies (forward/backward)
+            (trace_executor_found_dependency[c]) or 
+            {
+                // someother command finds a dependency
+                let backdep = (c.preprocessor_next' - c.preprocessor_next)  | {
+                    trace_executor_found_dependency[backdep]
+                }
+                
+                let forwarddep = (preprocessor_next'.c - preprocessor_next.c)  | {
+                    trace_executor_found_dependency[forwarddep]
+                }
+            }
+       }
        
+        }
     }
 
 ------------------------------------------------------------------------------------------------------
@@ -61,7 +76,6 @@ sig Command {
         {(c.command_state) = C} implies always (c.command_state = C)
         {(c.command_state) = CN} implies always (c.command_state = CN)
 
-        {(c.command_state) = C or (c.command_state = CN)} implies always (c.preprocessor_next' = c.preprocessor_next)
     }
 
     fun nonCommittedDependencies[c : Command, previous : set (Command -> Command)] : set Command
@@ -79,6 +93,7 @@ sig Command {
     // Command does not develop new preprocs
     pred preprocSame[c : Command] {
         c.preprocessor_next' = c.preprocessor_next
+        preprocessor_next'.c = preprocessor_next.c
     }
 
 ---------------------------------------------------------------------------------------------------------
@@ -90,8 +105,8 @@ sig Command {
         after (c.command_state = NE)
 
         (some nonCommittedDependencies[c, (~preprocessor_next)])
-        //TODO: is this correct?
-        preprocSame[c]
+
+        
     }
 
     // NE -> S
@@ -108,6 +123,10 @@ sig Command {
         after (c.command_state = NE)
 
         (some nonCommittedDependencies[c, dependency])
+
+        //TODO: shouldn't we have to specify something here?
+       
+
     }
 
     // S -> C
@@ -131,8 +150,6 @@ sig Command {
         c.command_state = NE
         after (c.command_state = NE)
         c not in firstNE[preprocessor_next]
-
-        preprocSame[c]
     }
 
     pred speculatively_execute[c : Command] {
@@ -145,7 +162,6 @@ sig Command {
     }
 
     pred validAction[c : Command] {
-       after(no (preprocessor_next & iden))
        awaiting_predecessors[c] or speculatively_execute[c] or run_trace_executor[c] or committed[c]
     }
 ------------------------------------------------------------------------------------------------
@@ -180,6 +196,7 @@ sig Command {
 pred dependency_preservation {
     all x : Command | committed[x] => always ((no x.^dependency) or committed[x.^dependency])
 }
+
 
 check { always (scheduler_e2e implies dependency_preservation)} for exactly 4 State, 6 Command
     

--- a/model-checking/scheduler.als
+++ b/model-checking/scheduler.als
@@ -30,45 +30,45 @@ sig Command {
         }
         no (r & ~r) // anti-symmetric
     }
-
     pred preprocWellFormed {
 
+        all c1,c2 : Command | {
+            
+            // Only remove edges which have been there since the beginning [preproc prediciton]
+            // and would violate the partial Order
+            (c1->c2) in (preprocessor_next - preprocessor_next') iff {
+                historically (c1->c2 in preprocessor_next) 
+                not partialOrder[preprocessor_next' + (c1->c2)]
+            }
+
+            // Adding an edge implies :
+            (c1->c2 in preprocessor_next' - preprocessor_next) implies {
+                (c1->c2) in ~dependency //should be a real dependency
+                some c3 : Command | {
+                    run_trace_executor[c3]
+                    // should be added by c2 (backward dependency) or due to transitivity
+                    (c3=c2) or 
+                    {
+                        c3 in c1.^preprocessor_next 
+                        c2 in c3.^preprocessor_next
+                    }
+                }
+            }
+
+            // if you run the trace executor with some non committed dependencies then you should add some edges
+            run_trace_executor[c1] and some (nonCommittedDependencies[c1,dependency]) implies {
+                some (preprocessor_next' - preprocessor_next)
+            }
+
+        }
         
-
-        // all c1,c2 : Command {
-        //     (c1->c2) in (preprocessor_next - preprocessor_next') iff {
-        //         not(partialOrder[preprocessor_next' + (c1->c2)])
-        //         not (c1->c2) in ~dependency
-        //         some c3 : Command | {
-        //             run_trace_executor[c3]
-        //             (c3 in (c1 + c2)) or 
-        //             ((c3 in c1.^preprocessor_next) and not(c3 in c2.^preprocessor_next)) 
-        //             not (c2 in (c3.^preprocessor_next'))
-        //         }
-        //     }
-        // }
-        // // Add edges from preprocessor_next if and only if it is a true dependency
-        // // and some command in the transitive closure must be being traced
-
-
-        // all c1,c2 : Command {
-        //     (c1->c2) in (preprocessor_next' - preprocessor_next)  iff {
-        //         (c1->c2) in ~dependency
-        //         some c3 : Command {
-        //             run_trace_executor[c3]
-        //             (c3 in (c1 + c2)) or 
-        //             ((c3 in c1.^preprocessor_next) and not(c3 in c2.^preprocessor_next)) 
-        //             (c2 in (c3.^preprocessor_next'))
-        //         }
-        //     }
-        // }
-
     }
-
     pred wellFormed {
         partialOrder[preprocessor_next]
         partialOrder[~dependency]
 
+        //The preprocessor does not have false negs
+        preprocWellFormed
     }
 
 ------------------------------------------------------------------------------------------------------
@@ -172,6 +172,7 @@ sig Command {
     // Initial state
     pred init {
         all c : Command | c.command_state = NE
+
     }
 
     // Scheduler behavior
@@ -199,8 +200,21 @@ check {final implies (always final)  } for exactly 4 State , 6 Command
 // This shows that the scheduler terminates, with all Commands committed.
 check  {scheduler_e2e implies (eventually final) } for exactly 4 State , 6 Command
 
-run {
-    scheduler_e2e
+// should be SAT
+run  {
+    scheduler_e2e 
     some dependency
-    no preprocessor_next
-} for exactly 4 State , 6 Command
+    no preprocessor_next  
+    } for exactly 4 State , 3 Command
+
+// should be UNSAT 
+run {
+    scheduler_e2e 
+    some dependency
+    some c1 ,c2 : Command {
+         (c1->c2) in preprocessor_next
+         (c1->c2) in ~dependency
+         
+        eventually( not (c1->c2 in preprocessor_next))
+    }
+}  for exactly 4 State , 6 Command

--- a/model-checking/scheduler.als
+++ b/model-checking/scheduler.als
@@ -22,6 +22,7 @@ sig Command {
 
 // Well Formedness
 
+
     pred partialOrder[r: set (Command -> Command)] {
         no r & iden // Anti-reflexivity
         all x: Command, y: Command, z: Command |
@@ -30,41 +31,61 @@ sig Command {
         }
         no (r & ~r) // anti-symmetric
     }
+    pred preprocWellFormed{
+        //This enforces the wellformedness of the preproc relation.
+        // We don't want preproc to arbitarily change it should only change if and only if 
+        // the trace executor finds a dependency. However a dependency may be discovered by another 
+        // command as well. Say for example C1 is not in the trace executor state but C2 is and discovers 
+        // a dependency on C1
+        
+        //  For all commands . The preproc relation affects the command C if and only if 
+        // either the trace executor finds a dependency for that command or some other 
+        // command finds a dependency on C. Any such new dependency must be a true dependency.
 
-    pred wellFormed {
-        partialOrder[preprocessor_next]
-        partialOrder[~dependency]
+        // NOTE: We want this here and not in trace_executor_found_dependency because otherwise
+        // trace_executor would be recursive.
 
-    // Maybe this should be a seperate predicate but this is enforcing wellformedness of
-    // the preproc relation.
-    // We don't want preproc to arbitarily change it should only change if and only if 
-    // the trace executor finds a dependency. However a dependency may be discovered by another 
-    // command as well. Say for example C1 is not in the trace executor state but C2 is and discovers 
-    // a dependency on C1
-       
-    //  For all commands . The preproc relation affects the command C if and only if 
-    // either the trace executor finds a dependency for that command or some other 
-    // command finds a dependency on C. Any such new dependency must be a true dependency.
-       all c : Command {
-         (not preprocSame[c]) iff { 
-            // The command find dependencies (forward/backward)
-            (trace_executor_found_dependency[c]) or 
-            {
-                // someother command finds a dependency
-                let backdep = (c.preprocessor_next' - c.preprocessor_next)  | {
-                    trace_executor_found_dependency[backdep]
-                    (backdep->c) in dependency
-                }
-                
-                let forwarddep = (preprocessor_next'.c - preprocessor_next.c)  | {
-                    trace_executor_found_dependency[forwarddep]
-                    (c->forwarddep) in dependency
+
+        // Remove edges from preprocessor_next if and only if it violates the partial order
+        // some command in the transitive closure must be being traced
+
+        all c1,c2 : Command {
+            (c1->c2) in (preprocessor_next - preprocessor_next') iff {
+                not(partialOrder[preprocessor_next' + (c1->c2)])
+                not (c1->c2) in ~dependency
+                some c3 : Command | {
+                    run_trace_executor[c3]
+                    (c3 in (c1 + c2)) or 
+                    ((c3 in c1.^preprocessor_next) and not(c3 in c2.^preprocessor_next)) 
+                    not (c2 in (c3.^preprocessor_next'))
                 }
             }
-       }
-       
+        }
+        // Add edges from preprocessor_next if and only if it is a true dependency
+        // and some command in the transitive closure must be being traced
+
+
+        all c1,c2 : Command {
+            (c1->c2) in (preprocessor_next' - preprocessor_next)  iff {
+                (c1->c2) in ~dependency
+                some c3 : Command {
+                    run_trace_executor[c3]
+                    (c3 in (c1 + c2)) or 
+                    ((c3 in c1.^preprocessor_next) and not(c3 in c2.^preprocessor_next)) 
+                    (c2 in (c3.^preprocessor_next'))
+                }
+            }
+        }
+
     }
+
+    pred wellFormed {
+        // partialOrder[preprocessor_next] This is now true only of init and becomes a property to check
+        partialOrder[~dependency]
+        preprocWellFormed
+
     }
+
 
 ------------------------------------------------------------------------------------------------------
 
@@ -91,13 +112,6 @@ sig Command {
     fun nonCommittedDependencies[c : Command, previous : set (Command -> Command)] : set Command
     {
         {x : Command | (x in c.^previous) and !committed[x] }
-    }
-    pred nonCommittedDep[c : Command] 
-    {
-        some newdep : Command {
-            !committed[newdep]
-            after(c in newdep.preprocessor_next)
-        }
     }
     
     // Command does not develop new preprocs
@@ -132,7 +146,6 @@ sig Command {
 
         (some nonCommittedDependencies[c, dependency])
 
-        //TODO: shouldn't we have to specify something here?
     }
 
     // S -> C
@@ -165,7 +178,9 @@ sig Command {
 
     pred run_trace_executor[c : Command] {
         trace_executor_found_dependency[c] or commit_frontier[c] or speculated_not_executed[c]
+
     }
+
 
     pred validAction[c : Command] {
        awaiting_predecessors[c] or speculatively_execute[c] or run_trace_executor[c] or committed[c]
@@ -183,6 +198,8 @@ sig Command {
     // Initial state
     pred init {
         all c : Command | c.command_state = NE
+        // Only the initial state should be partial order everything else is enforced through transitions
+        partialOrder[preprocessor_next] 
     }
 
     // Scheduler behavior
@@ -203,17 +220,26 @@ pred dependency_preservation {
     all x : Command | committed[x] => always ((no x.^dependency) or committed[x.^dependency])
 }
 
-run{
-    scheduler_e2e
-    some dependency
-    no preprocessor_next 
-    #dependency >= 4
-    } for exactly 4 State, exactly 6 Command
-
-check { always (scheduler_e2e implies dependency_preservation)} for exactly 4 State, 6 Command
+check { always (scheduler_e2e implies dependency_preservation)} for exactly 4 State, 3 Command
     
 // Once terminated, nothing is scheduled.
-check {final implies (always final)  } for exactly 4 State , 6 Command
+check {final implies (always final)  } for exactly 4 State , 3 Command
 // This shows that the scheduler terminates, with all Commands committed.
-check  {scheduler_e2e implies (eventually final) } for exactly 4 State ,6 Command
+check  {scheduler_e2e implies (eventually final) } for exactly 4 State ,3 Command
 
+// We always have a partial order if we start off with one
+check { always (scheduler_e2e implies always(partialOrder[preprocessor_next]))} for exactly 4 State, 3 Command
+
+
+// Sanity checks
+
+// This is failing!!!
+run{
+   scheduler_e2e
+    some dependency
+    no preprocessor_next
+    } for exactly 4 State,  3 Command
+
+run{
+    scheduler_e2e
+    } for exactly 4 State,  6 Command

--- a/model-checking/scheduler.als
+++ b/model-checking/scheduler.als
@@ -13,7 +13,7 @@ sig Command {
     var command_state: one State,
 
     -- These are the dependencies predicted by the preprocessor.
-    preprocessor_next : set Command,    
+    var preprocessor_next : set Command,    
     -- These are the real dependencies, that will only be found by the trace executor.
     dependency: set Command
 }
@@ -35,8 +35,10 @@ sig Command {
         partialOrder[preprocessor_next]
         partialOrder[~dependency]
 
-        //The preprocessor does not have false negs
-       preprocessor_next in ~dependency
+        //The preprocessor does not create a cycle with the actual dependencies
+        no (^preprocessor_next).(^~dependency)
+       
+       
     }
 
 ------------------------------------------------------------------------------------------------------
@@ -58,11 +60,25 @@ sig Command {
 
         {(c.command_state) = C} implies always (c.command_state = C)
         {(c.command_state) = CN} implies always (c.command_state = CN)
+
+        {(c.command_state) = C or (c.command_state = CN)} implies always (c.preprocessor_next' = c.preprocessor_next)
     }
 
     fun nonCommittedDependencies[c : Command, previous : set (Command -> Command)] : set Command
     {
         {x : Command | (x in c.^previous) and !committed[x] }
+    }
+    pred nonCommittedDep[c : Command] 
+    {
+        some newdep : Command {
+            !committed[newdep]
+            after(c in newdep.preprocessor_next)
+        }
+    }
+    
+    // Command does not develop new preprocs
+    pred preprocSame[c : Command] {
+        c.preprocessor_next' = c.preprocessor_next
     }
 
 ---------------------------------------------------------------------------------------------------------
@@ -74,6 +90,8 @@ sig Command {
         after (c.command_state = NE)
 
         (some nonCommittedDependencies[c, (~preprocessor_next)])
+        //TODO: is this correct?
+        preprocSame[c]
     }
 
     // NE -> S
@@ -95,7 +113,7 @@ sig Command {
     // S -> C
     pred commit_frontier[c : Command] {
         c.command_state = S
-         after (c.command_state = C )
+        after (c.command_state = C )
 
         (no nonCommittedDependencies[c, dependency])
     }
@@ -113,6 +131,8 @@ sig Command {
         c.command_state = NE
         after (c.command_state = NE)
         c not in firstNE[preprocessor_next]
+
+        preprocSame[c]
     }
 
     pred speculatively_execute[c : Command] {
@@ -125,6 +145,7 @@ sig Command {
     }
 
     pred validAction[c : Command] {
+       after(no (preprocessor_next & iden))
        awaiting_predecessors[c] or speculatively_execute[c] or run_trace_executor[c] or committed[c]
     }
 ------------------------------------------------------------------------------------------------
@@ -165,5 +186,5 @@ check { always (scheduler_e2e implies dependency_preservation)} for exactly 4 St
 // Once terminated, nothing is scheduled.
 check {final implies (always final)  } for exactly 4 State , 6 Command
 // This shows that the scheduler terminates, with all Commands committed.
-check  {scheduler_e2e implies (eventually final) } for exactly 4 State , 6 Command
+check  {scheduler_e2e implies (eventually final) } for exactly 4 State ,6 Command
 

--- a/model-checking/scheduler.als
+++ b/model-checking/scheduler.als
@@ -35,7 +35,16 @@ sig Command {
         partialOrder[preprocessor_next]
         partialOrder[~dependency]
 
+    // Maybe this should be a seperate predicate but this is enforcing wellformedness of
+    // the preproc relation.
+    // We don't want preproc to arbitarily change it should only change if and only if 
+    // the trace executor finds a dependency. However a dependency may be discovered by another 
+    // command as well. Say for example C1 is not in the trace executor state but C2 is and discovers 
+    // a dependency on C1
        
+    //  For all commands . The preproc relation affects the command C if and only if 
+    // either the trace executor finds a dependency for that command or some other 
+    // command finds a dependency on C. Any such new dependency must be a true dependency.
        all c : Command {
          (not preprocSame[c]) iff { 
             // The command find dependencies (forward/backward)
@@ -54,7 +63,7 @@ sig Command {
             }
        }
        
-        }
+    }
     }
 
 ------------------------------------------------------------------------------------------------------

--- a/model-checking/scheduler.als
+++ b/model-checking/scheduler.als
@@ -35,7 +35,6 @@ sig Command {
         partialOrder[preprocessor_next]
         partialOrder[~dependency]
 
-        //The preprocessor does not create a cycle with the actual dependencies
        
        all c : Command {
          (not preprocSame[c]) iff { 
@@ -45,10 +44,12 @@ sig Command {
                 // someother command finds a dependency
                 let backdep = (c.preprocessor_next' - c.preprocessor_next)  | {
                     trace_executor_found_dependency[backdep]
+                    (backdep->c) in dependency
                 }
                 
                 let forwarddep = (preprocessor_next'.c - preprocessor_next.c)  | {
                     trace_executor_found_dependency[forwarddep]
+                    (c->forwarddep) in dependency
                 }
             }
        }
@@ -105,8 +106,6 @@ sig Command {
         after (c.command_state = NE)
 
         (some nonCommittedDependencies[c, (~preprocessor_next)])
-
-        
     }
 
     // NE -> S
@@ -125,8 +124,6 @@ sig Command {
         (some nonCommittedDependencies[c, dependency])
 
         //TODO: shouldn't we have to specify something here?
-       
-
     }
 
     // S -> C
@@ -197,6 +194,12 @@ pred dependency_preservation {
     all x : Command | committed[x] => always ((no x.^dependency) or committed[x.^dependency])
 }
 
+run{
+    scheduler_e2e
+    some dependency
+    no preprocessor_next 
+    #dependency >= 4
+    } for exactly 4 State, exactly 6 Command
 
 check { always (scheduler_e2e implies dependency_preservation)} for exactly 4 State, 6 Command
     

--- a/model-checking/scheduler.als
+++ b/model-checking/scheduler.als
@@ -22,7 +22,6 @@ sig Command {
 
 // Well Formedness
 
-
     pred partialOrder[r: set (Command -> Command)] {
         no r & iden // Anti-reflexivity
         all x: Command, y: Command, z: Command |
@@ -31,61 +30,46 @@ sig Command {
         }
         no (r & ~r) // anti-symmetric
     }
-    pred preprocWellFormed{
-        //This enforces the wellformedness of the preproc relation.
-        // We don't want preproc to arbitarily change it should only change if and only if 
-        // the trace executor finds a dependency. However a dependency may be discovered by another 
-        // command as well. Say for example C1 is not in the trace executor state but C2 is and discovers 
-        // a dependency on C1
+
+    pred preprocWellFormed {
+
         
-        //  For all commands . The preproc relation affects the command C if and only if 
-        // either the trace executor finds a dependency for that command or some other 
-        // command finds a dependency on C. Any such new dependency must be a true dependency.
 
-        // NOTE: We want this here and not in trace_executor_found_dependency because otherwise
-        // trace_executor would be recursive.
-
-
-        // Remove edges from preprocessor_next if and only if it violates the partial order
-        // some command in the transitive closure must be being traced
-
-        all c1,c2 : Command {
-            (c1->c2) in (preprocessor_next - preprocessor_next') iff {
-                not(partialOrder[preprocessor_next' + (c1->c2)])
-                not (c1->c2) in ~dependency
-                some c3 : Command | {
-                    run_trace_executor[c3]
-                    (c3 in (c1 + c2)) or 
-                    ((c3 in c1.^preprocessor_next) and not(c3 in c2.^preprocessor_next)) 
-                    not (c2 in (c3.^preprocessor_next'))
-                }
-            }
-        }
-        // Add edges from preprocessor_next if and only if it is a true dependency
-        // and some command in the transitive closure must be being traced
+        // all c1,c2 : Command {
+        //     (c1->c2) in (preprocessor_next - preprocessor_next') iff {
+        //         not(partialOrder[preprocessor_next' + (c1->c2)])
+        //         not (c1->c2) in ~dependency
+        //         some c3 : Command | {
+        //             run_trace_executor[c3]
+        //             (c3 in (c1 + c2)) or 
+        //             ((c3 in c1.^preprocessor_next) and not(c3 in c2.^preprocessor_next)) 
+        //             not (c2 in (c3.^preprocessor_next'))
+        //         }
+        //     }
+        // }
+        // // Add edges from preprocessor_next if and only if it is a true dependency
+        // // and some command in the transitive closure must be being traced
 
 
-        all c1,c2 : Command {
-            (c1->c2) in (preprocessor_next' - preprocessor_next)  iff {
-                (c1->c2) in ~dependency
-                some c3 : Command {
-                    run_trace_executor[c3]
-                    (c3 in (c1 + c2)) or 
-                    ((c3 in c1.^preprocessor_next) and not(c3 in c2.^preprocessor_next)) 
-                    (c2 in (c3.^preprocessor_next'))
-                }
-            }
-        }
+        // all c1,c2 : Command {
+        //     (c1->c2) in (preprocessor_next' - preprocessor_next)  iff {
+        //         (c1->c2) in ~dependency
+        //         some c3 : Command {
+        //             run_trace_executor[c3]
+        //             (c3 in (c1 + c2)) or 
+        //             ((c3 in c1.^preprocessor_next) and not(c3 in c2.^preprocessor_next)) 
+        //             (c2 in (c3.^preprocessor_next'))
+        //         }
+        //     }
+        // }
 
     }
 
     pred wellFormed {
-        // partialOrder[preprocessor_next] This is now true only of init and becomes a property to check
+        partialOrder[preprocessor_next]
         partialOrder[~dependency]
-        preprocWellFormed
 
     }
-
 
 ------------------------------------------------------------------------------------------------------
 
@@ -106,18 +90,11 @@ sig Command {
 
         {(c.command_state) = C} implies always (c.command_state = C)
         {(c.command_state) = CN} implies always (c.command_state = CN)
-
     }
 
     fun nonCommittedDependencies[c : Command, previous : set (Command -> Command)] : set Command
     {
         {x : Command | (x in c.^previous) and !committed[x] }
-    }
-    
-    // Command does not develop new preprocs
-    pred preprocSame[c : Command] {
-        c.preprocessor_next' = c.preprocessor_next
-        preprocessor_next'.c = preprocessor_next.c
     }
 
 ---------------------------------------------------------------------------------------------------------
@@ -145,13 +122,12 @@ sig Command {
         after (c.command_state = NE)
 
         (some nonCommittedDependencies[c, dependency])
-
     }
 
     // S -> C
     pred commit_frontier[c : Command] {
         c.command_state = S
-        after (c.command_state = C )
+         after (c.command_state = C )
 
         (no nonCommittedDependencies[c, dependency])
     }
@@ -178,9 +154,7 @@ sig Command {
 
     pred run_trace_executor[c : Command] {
         trace_executor_found_dependency[c] or commit_frontier[c] or speculated_not_executed[c]
-
     }
-
 
     pred validAction[c : Command] {
        awaiting_predecessors[c] or speculatively_execute[c] or run_trace_executor[c] or committed[c]
@@ -198,8 +172,6 @@ sig Command {
     // Initial state
     pred init {
         all c : Command | c.command_state = NE
-        // Only the initial state should be partial order everything else is enforced through transitions
-        partialOrder[preprocessor_next] 
     }
 
     // Scheduler behavior
@@ -220,26 +192,15 @@ pred dependency_preservation {
     all x : Command | committed[x] => always ((no x.^dependency) or committed[x.^dependency])
 }
 
-check { always (scheduler_e2e implies dependency_preservation)} for exactly 4 State, 3 Command
+check { always (scheduler_e2e implies dependency_preservation)} for exactly 4 State, 6 Command
     
 // Once terminated, nothing is scheduled.
-check {final implies (always final)  } for exactly 4 State , 3 Command
+check {final implies (always final)  } for exactly 4 State , 6 Command
 // This shows that the scheduler terminates, with all Commands committed.
-check  {scheduler_e2e implies (eventually final) } for exactly 4 State ,3 Command
+check  {scheduler_e2e implies (eventually final) } for exactly 4 State , 6 Command
 
-// We always have a partial order if we start off with one
-check { always (scheduler_e2e implies always(partialOrder[preprocessor_next]))} for exactly 4 State, 3 Command
-
-
-// Sanity checks
-
-// This is failing!!!
-run{
-   scheduler_e2e
+run {
+    scheduler_e2e
     some dependency
     no preprocessor_next
-    } for exactly 4 State,  3 Command
-
-run{
-    scheduler_e2e
-    } for exactly 4 State,  6 Command
+} for exactly 4 State , 6 Command


### PR DESCRIPTION
Slight changes to the prototype that remove making any assumptions about the preprocessor (previously it was assumed there were no false negatives). 

