### PR TITLE
fix(overlay-sandbox): add ubuntu default snap and swap to ignore list

### DIFF
--- a/overlay-sandbox/mount-and-execute.sh
+++ b/overlay-sandbox/mount-and-execute.sh
@@ -5,7 +5,7 @@ export script_to_execute=${2?No script is given to execute}
 
 ## TODO: Figure out if we need these directories and if we do, we need to get them some other way than the overlay
 ubuntu22_ignore_directories=" -e snap -e swap.img"
-ignore_directories="-e proc -e dev -e proj -e run -e sys "$ubuntu22_ignore_directories
+ignore_directories="-e proc -e dev -e proj -e run -e sys"$ubuntu22_ignore_directories
 ls / | grep -v ${ignore_directories} | xargs -I '{}' mount -t overlay overlay -o lowerdir=/'{}',upperdir="$SANDBOX_DIR"/upperdir/'{}',workdir="$SANDBOX_DIR"/workdir/'{}' "$SANDBOX_DIR"/temproot/'{}'
 
 # TODO: use unshare instead of chroot

--- a/overlay-sandbox/mount-and-execute.sh
+++ b/overlay-sandbox/mount-and-execute.sh
@@ -4,7 +4,8 @@ export SANDBOX_DIR=${1?No sandbox dir given}
 export script_to_execute=${2?No script is given to execute}
 
 ## TODO: Figure out if we need these directories and if we do, we need to get them some other way than the overlay
-ignore_directories="-e proc -e dev -e proj -e run -e sys -e snap -e swap.img"
+ubuntu22_ignore_directories=" -e snap -e swap.img"
+ignore_directories="-e proc -e dev -e proj -e run -e sys "$ubuntu22_ignore_directories
 ls / | grep -v ${ignore_directories} | xargs -I '{}' mount -t overlay overlay -o lowerdir=/'{}',upperdir="$SANDBOX_DIR"/upperdir/'{}',workdir="$SANDBOX_DIR"/workdir/'{}' "$SANDBOX_DIR"/temproot/'{}'
 
 # TODO: use unshare instead of chroot

--- a/overlay-sandbox/mount-and-execute.sh
+++ b/overlay-sandbox/mount-and-execute.sh
@@ -4,7 +4,7 @@ export SANDBOX_DIR=${1?No sandbox dir given}
 export script_to_execute=${2?No script is given to execute}
 
 ## TODO: Figure out if we need these directories and if we do, we need to get them some other way than the overlay
-ignore_directories="-e proc -e dev -e proj -e run -e sys"
+ignore_directories="-e proc -e dev -e proj -e run -e sys -e snap -e swap.img"
 ls / | grep -v ${ignore_directories} | xargs -I '{}' mount -t overlay overlay -o lowerdir=/'{}',upperdir="$SANDBOX_DIR"/upperdir/'{}',workdir="$SANDBOX_DIR"/workdir/'{}' "$SANDBOX_DIR"/temproot/'{}'
 
 # TODO: use unshare instead of chroot


### PR DESCRIPTION
The default Ubuntu 22.04 machine creates /snap and /swap.img by default, this PR adds the two to the ignore list in `overlay-sandbox/run-sandboxed.sh`

```
mount: /tmp/pash_spec/sandbox_ArMkXzX/temproot/snap: wrong fs type, bad option, bad superblock on overlay, missing codepage or helper program, or other error.
mount: /tmp/pash_spec/sandbox_ArMkXzX/temproot/swap.img: wrong fs type, bad option, bad superblock on overlay, missing codepage or helper program, or other error.
```