### PR TITLE
Continuous Scheduler

### DIFF
--- a/parallel-orch/executor.py
+++ b/parallel-orch/executor.py
@@ -11,6 +11,10 @@ def async_run_and_trace_command_return_trace(command, node_id, sandbox_mode=Fals
     process = async_run_and_trace_command(command, trace_file, node_id, sandbox_mode)
     return process, trace_file
 
+def async_run_and_trace_command_return_trace_in_sandbox(command, node_id):
+    process, trace_file = async_run_and_trace_command_return_trace(command, node_id, sandbox_mode=True)
+    return process, trace_file
+
 def async_run_and_trace_command(command, trace_file, node_id, sandbox_mode=False):
     ## Call Riker to execute the command
     run_script = f'{config.PASH_SPEC_TOP}/parallel-orch/run_command.sh'

--- a/parallel-orch/partial_program_order.py
+++ b/parallel-orch/partial_program_order.py
@@ -62,6 +62,7 @@ class PartialProgramOrder:
         self.workset = []
         ## A dictionary from cmd_ids that are currently executing that contains their trace_files
         self.commands_currently_executing = {}
+        self.to_be_resolved = set()
     
     def __str__(self):
         return f"NODES: {len(self.nodes.keys())} | ADJACENCY: {self.adjacency}"
@@ -133,13 +134,24 @@ class PartialProgramOrder:
     
     def get_transitive_closure(self, target_node_ids:list) -> list:
         all_next_transitive = set(target_node_ids)
-        workset = target_node_ids.copy()
-        while len(workset) > 0:
-            node_id = workset.pop()
+        next_work = target_node_ids.copy()
+        while len(next_work) > 0:
+            node_id = next_work.pop()
             successors = set(self.get_next(node_id))
             new_next = successors - all_next_transitive
             all_next_transitive = all_next_transitive.union(successors)
-            workset.extend(new_next)
+            next_work.extend(new_next)
+        return list(all_next_transitive)
+
+    def get_transitive_closure_if_can_be_resolved(self, can_be_resolved: list, target_node_ids: list) -> list:
+        all_next_transitive = set(target_node_ids)
+        next_work = target_node_ids.copy()
+        while len(next_work) > 0:
+            node_id = next_work.pop()
+            successors = {next_node_id for next_node_id in self.get_next(node_id) if next_node_id in can_be_resolved}
+            new_next = successors - all_next_transitive
+            all_next_transitive = all_next_transitive.union(successors)
+            next_work.extend(new_next)
         return list(all_next_transitive)
 
     def is_frontier(self, node_id: int) -> bool:
@@ -167,39 +179,129 @@ class PartialProgramOrder:
                 return node_id
         assert(False)
 
+
+    # If the cmd id is less than
+    def can_be_resolved(self, node_id: int) -> bool:
+        logging.debug(f"Examining if can be resolved: {node_id}, {self.get_currently_executing()}")
+        if len(self.get_currently_executing()) > 0:
+            return node_id < min(self.get_currently_executing())
+        else:
+            return True
+
+
+    def find_cmds_to_resolve(self, cmd_ids_to_check: list):
+        cmds_to_resolve = []
+        logging.debug(f"Cmds to check: {cmd_ids_to_check}")
+        for cmd_id in cmd_ids_to_check:
+            # We check if we can resolve any possible dependencies
+            # If we can't, we have to wait for another cycle
+            if not self.can_be_resolved(cmd_id):
+                if cmd_id not in self.to_be_resolved:
+                    logging.debug(f"> Adding node {cmd_id} to waiting list")
+                    self.to_be_resolved.add(cmd_id)
+                else:
+                    logging.debug(f"> Keeping node {cmd_id} to waiting list")
+            # If we are in this branch it means that we can resolve the dependencies of the current command
+            else:
+                cmds_to_resolve.append(cmd_id)
+                # We remove the command from the waiting to be resolved set
+                logging.debug(f"> Removing node {cmd_id} from waiting list")
+                self.to_be_resolved.discard(cmd_id)
+        logging.debug(sorted(cmds_to_resolve))
+        return sorted(cmds_to_resolve)
+
+
     ## Resolve all the forward dependencies and update the workset
     ## Forward dependency is when a command's output is the same
     ## as the input of a following command
-    def resolve_dependencies(self):
-        new_workset = []
-        for first_cmd_id in self.get_workset():
+    def resolve_dependencies_continuous(self, new_node_id):
+        logging.debug(f"Node to be examined ----> {new_node_id}")
+        self.log_partial_program_order_info()
+        # We want to check every single command that has already finished executing but
+        # not yet able to be resolved
+        cmds_to_resolve = self.find_cmds_to_resolve(sorted(list(self.to_be_resolved.union({new_node_id}))))
+        # If no commands can be resolved this round, do nothing and wait until a new command finishes executing
+        if len(cmds_to_resolve) == 0:
+            return
+        
+        # Commit right away as it is the only command to resolve
+        if len(cmds_to_resolve) == 1:
+            to_commit = cmds_to_resolve.pop()
+            self.committed.add(to_commit)
+            # If cmd exists in speculated it means it should have been resolved 
+            # in a cycle with len(cmds_to_resolve) > 1
+            assert(to_commit not in self.speculated)
+            self.workset.remove(to_commit)
+            # The cmd should also be in the frontier
+            assert(to_commit in self.frontier)
+            self.frontier.remove(to_commit)
+            self.frontier.extend(self.get_next(to_commit))
+            return
+        # If we reach this point, we follow the traditional cycle approach
+        # This will help us determine the new specualted set
+        independent_cmds_this_cycle = set(cmds_to_resolve)
+        # This doesn't work for true partial program order
+        # TODO: use get_transitive_closure()
+        new_workset = {}
+        for first_cmd_id in cmds_to_resolve:
             # We don't want the first cmd, so we remove it from the transitive closure.
-            transitive_closure = self.get_transitive_closure([first_cmd_id])
+            transitive_closure = self.get_transitive_closure_if_can_be_resolved(cmds_to_resolve, [first_cmd_id])
             transitive_closure.remove(first_cmd_id)
             # We look at the transitive closure instead of workset because we want to also check the speculated cmds that are not in the workset
             for second_cmd_id in transitive_closure:
                 # If no anti-dependencies exist, we proceed to check for dependencies
-                ## TODO:  We need to keep track of invalidations continuously, which is non trivial!
+                ## TODO: We need to keep track of invalidations continuously, which is non trivial!
                 if second_cmd_id not in new_workset:
                     ## If it is None, it means that it has not executed at all,
                     ## so we need to add it in the workset
                     if self.get_rw_set(second_cmd_id) is None:
                         ## TODO: Check if this could lead to overwork
                         logging.debug(f'Command: {second_cmd_id} was added to the workset, because it was never executed before')
-                        new_workset.append(second_cmd_id)
+                        new_workset.add(second_cmd_id)
                     elif self.has_backward_dependency(first_cmd_id, second_cmd_id) or self.has_write_dependency(first_cmd_id, second_cmd_id) or self.has_forward_dependency(first_cmd_id, second_cmd_id):
                         ## TODO: make the logging more precise, what type of dependency
                         ## TODO: Check for overwork
                         logging.debug(f'Command: {second_cmd_id} was added to the workset, due to a dependency')
-                        new_workset.append(second_cmd_id)                    
-        # Set the new speculated set
-        
+                        new_workset.add(second_cmd_id)
+        logging.debug(f"!!!!!!!!!!!!!!!{new_workset}")
+
         old_speculated = self.speculated.copy()
-        self.speculated = {cmd_id for cmd_id in self.workset if cmd_id not in new_workset and cmd_id not in self.frontier}
+        self.speculated = {cmd_id for cmd_id in cmds_to_resolve if cmd_id not in new_workset and cmd_id not in self.frontier}
         # Set the new workset
         self.workset = new_workset
-        self.step_forward(old_speculated)        
+        self.step_forward_continuous(cmds_to_resolve, old_speculated)
 
+    def step_forward(self, old_speculated, cmds_to_resolve):
+        self.commit_frontier(cmds_to_resolve)
+        self.move_frontier_forward(old_speculated, cmds_to_resolve)
+
+    # Add frontier commands to committed set
+    def commit_frontier(self, cmds_to_resolve):
+        # Second condition below may be unecessary
+        self.committed.update({frontier_node for frontier_node in self.frontier in frontier_node in cmds_to_resolve})
+
+    def move_frontier_node_forward(self, old_speculated: set, cmds_to_resolve: set):
+        new_frontier = []
+        for node in self.frontier:
+            if node in cmds_to_resolve:
+                new_frontier.extend(self.get_next_non_speculated_continuous(node, old_speculated, cmds_to_resolve))
+        self.frontier.discard(node)
+        self.frontier.node.extend(new_frontier)
+
+    def get_next_non_speculated(self, start, old_speculated: set, cmds_to_resolve):
+            traversal_workset = self.get_next(start)
+            next_non_speculated = []
+            while len(traversal_workset) > 0:
+                node_id = traversal_workset.pop()
+                if node_id in cmds_to_resolve:
+                    if node_id in old_speculated.union(self.speculated):
+                        self.speculated.discard(node_id)
+                        self.committed.add(node_id)
+                        traversal_workset.extend(self.get_next(node_id))
+                    else:
+                        next_non_speculated.append(node_id)
+            return next_non_speculated
+  
     def has_forward_dependency(self, first_id, second_id):
         first_write_set = set(self.rw_sets[first_id].get_write_set())
         second_read_set = set(self.rw_sets[second_id].get_read_set())
@@ -215,37 +317,6 @@ class PartialProgramOrder:
         second_read_set = set(self.rw_sets[second_id].get_write_set())
         return not first_write_set.isdisjoint(second_read_set)
 
-    # We want to commit the current frontier node(s),
-    # move the frontier one step forward
-    # and then generate the new workset,
-    # ignoring the speculated cmds
-    def step_forward(self, old_speculated: set):
-        self.commit_frontier()
-        self.move_frontier_forward(old_speculated)
-
-    # Add frontier commands to committed set
-    def commit_frontier(self):
-        self.committed.update(self.frontier)
-
-    def move_frontier_forward(self, old_speculated: set):
-        new_frontier = []
-        for node in self.frontier:
-            new_frontier.extend(self.get_next_non_speculated(node, old_speculated))
-        self.frontier = new_frontier
-
-    def get_next_non_speculated(self, start, old_speculated: set):
-        traversal_workset = self.get_next(start)
-        next_non_speculated = []
-        while len(traversal_workset) > 0:
-            node_id = traversal_workset.pop()
-            if node_id in old_speculated.union(self.speculated):
-                self.speculated.discard(node_id)
-                self.committed.add(node_id)
-                traversal_workset.extend(self.get_next(node_id))
-            else:
-                next_non_speculated.append(node_id)
-        return next_non_speculated
-    
     ## TODO: Eventually, in the future, let's add here some form of limit
     def schedule_work(self, limit=0):
         self.run_all_frontier_cmds()
@@ -295,13 +366,12 @@ class PartialProgramOrder:
     def command_execution_completed(self, node_id: int):
         _proc, trace_file = self.commands_currently_executing.pop(node_id)
         trace_object = executor.read_trace(trace_file)
-        # print(trace_object)
         read_set, write_set = trace.parse_and_gather_cmd_rw_sets(trace_object)
         rw_set = RWSet(read_set, write_set)
         self.update_rw_set(node_id, rw_set)
 
         ## TODO: Maybe we can just resolve dependencies of a single command and not the whole workset.
-        self.resolve_dependencies()
+        self.resolve_dependencies_continuous(node_id)
 
 
     def log_rw_sets(self, logging):
@@ -311,13 +381,26 @@ class PartialProgramOrder:
             logging.debug(f"Read: {rw_set.get_read_set()}")
             logging.debug(f"Write: {rw_set.get_write_set()}")
 
+    def log_rw_sets(self):
+        logging.debug("====== |RW Sets| ======")
+        for node_id, rw_set in self.rw_sets.items():
+            logging.debug(f"ID: {node_id}")
+            logging.debug(f"Read: {len(rw_set.get_read_set()) if rw_set is not None else None}")
+            logging.debug(f"Write: {len(rw_set.get_write_set()) if rw_set is not None else None}")
+
     def log_partial_program_order_info(self):
         logging.debug(f"=" * 60)
-        logging.debug(f"WORKSET:{self.get_workset()}")
-        logging.debug(f"COMMITTED:{self.get_committed()}")
-        logging.debug(f"FRONTIER:{self.get_frontier()}")
-        logging.debug(f"SPECULATED:{self.get_speculated()}")
+        logging.debug(f"WORKSET:    {self.get_workset()}")
+        logging.debug(f"COMMITTED:  {self.get_committed()}")
+        logging.debug(f"FRONTIER:   {self.get_frontier()}")
+        logging.debug(f"SPECULATED: {self.get_speculated()}")
+        logging.debug(f"EXECUTING:  {list(self.commands_currently_executing.keys())}")
+        logging.debug(f"WAITING:    {sorted(list(self.to_be_resolved))}")
         logging.debug(f"=" * 60)
+
+    def get_currently_executing(self) -> list:
+        return sorted(list(self.commands_currently_executing.keys()))
+
 
 def parse_cmd_from_file(file_path: str) -> str:
     with open(file_path) as f:
@@ -354,8 +437,6 @@ def parse_partial_program_order_from_file(file_path: str) -> PartialProgramOrder
         file_path = f'{cmds_directory}/{i}'
         cmd = parse_cmd_from_file(file_path)
         nodes[i] = Node(i, cmd)
-
-    # print(nodes)
 
     edges = {i : [] for i in range(number_of_nodes)}
     for edge_line in edge_lines:

--- a/parallel-orch/partial_program_order.py
+++ b/parallel-orch/partial_program_order.py
@@ -62,7 +62,8 @@ class PartialProgramOrder:
         self.workset = []
         ## A dictionary from cmd_ids that are currently executing that contains their trace_files
         self.commands_currently_executing = {}
-        self.to_be_resolved = set()
+        self.to_be_resolved = {}
+        self.waiting_to_be_resolved = set()
     
     def __str__(self):
         return f"NODES: {len(self.nodes.keys())} | ADJACENCY: {self.adjacency}"
@@ -154,6 +155,17 @@ class PartialProgramOrder:
             next_work.extend(new_next)
         return list(all_next_transitive)
 
+        # def get_inverse_transitive_closure_if_can_be_resolved(self, can_be_resolved: list, target_node_ids: list) -> list:
+        # all_next_transitive = set(target_node_ids)
+        # next_work = target_node_ids.copy()
+        # while len(next_work) > 0:
+        #     node_id = next_work.pop()
+        #     successors = {next_node_id for next_node_id in self.get_next(node_id) if next_node_id in can_be_resolved}
+        #     new_next = successors - all_next_transitive
+        #     all_next_transitive = all_next_transitive.union(successors)
+        #     next_work.extend(new_next)
+        # return list(all_next_transitive)
+
     def is_frontier(self, node_id: int) -> bool:
         return node_id in self.frontier
     
@@ -185,7 +197,7 @@ class PartialProgramOrder:
     def cmd_can_be_resolved(self, node_id: int) -> bool:
         # If the command we evaluate has no earlier command currently executing, it can be resolved this round
         if len(self.get_currently_executing()) > 0:
-            return node_id < min(self.get_currently_executing())
+            return node_id <= min(self.get_currently_executing())
         else:
             return True
     
@@ -196,18 +208,18 @@ class PartialProgramOrder:
             # We check if we can resolve any possible dependencies
             # If we can't, we have to wait for another cycle
             if not self.cmd_can_be_resolved(cmd_id):
-                if cmd_id not in self.to_be_resolved:
+                if cmd_id not in self.waiting_to_be_resolved:
                     logging.debug(f" > Adding node {cmd_id} to waiting list")
-                    self.to_be_resolved.add(cmd_id)
+                    self.waiting_to_be_resolved.add(cmd_id)
                 else:
                     logging.debug(f" > Keeping node {cmd_id} to waiting list")
             # If we are in this branch it means that we can resolve the dependencies of the current command
             else:
                 cmds_to_resolve.append(cmd_id)
                 # We remove the command from the waiting to be resolved set
-                if cmd_id in self.to_be_resolved:
+                if cmd_id in self.waiting_to_be_resolved:
                     logging.debug(f" > Removing node {cmd_id} from waiting list")
-                    self.to_be_resolved.remove(cmd_id)
+                    self.waiting_to_be_resolved.remove(cmd_id)
                 else:
                     logging.debug(f" > Node {cmd_id} is able to be resolved")
         return sorted(cmds_to_resolve)
@@ -220,9 +232,10 @@ class PartialProgramOrder:
         # We want to check every single command that has already finished executing but
         # not yet able to be resolved
         logging.debug("Finding sets of commands that can be resolved after {new_node_id} finished executing")
-        cmds_to_resolve = self.find_cmds_to_resolve(sorted(list(self.to_be_resolved.union({new_node_id}))))
+        cmds_to_resolve = self.find_cmds_to_resolve(sorted(list(self.waiting_to_be_resolved.union({new_node_id}))))
+        
         logging.debug(f"Commands to check for dependencies this round are:  {sorted(cmds_to_resolve)}")
-        logging.debug(f"Commands that can not be resolved this round are:   {sorted(self.to_be_resolved)}")
+        logging.debug(f"Commands that can not be resolved this round are:   {sorted(self.waiting_to_be_resolved)}")
         
         # If no commands can be resolved this round, 
         # do nothing and wait until a new command finishes executing
@@ -236,14 +249,11 @@ class PartialProgramOrder:
         old_workset = self.workset.copy()
         logging.debug(" --- Starting dependency resolution --- ")
         logging.debug(f"Commands to be checked for dependencies: {sorted(cmds_to_resolve)}")
-        for first_cmd_id in cmds_to_resolve:
-            # We don't want the first cmd, so we remove it from the transitive closure.
-            transitive_closure = self.get_transitive_closure_if_can_be_resolved(cmds_to_resolve, [first_cmd_id])
-            transitive_closure.remove(first_cmd_id)
-            logging.debug(f" > Resolvable transitive closure for node {first_cmd_id} is: {transitive_closure}")
-            # We look at the transitive closure instead of workset because we want to also check the speculated cmds that are not in the workset
-            for second_cmd_id in transitive_closure:
-                # If cmd already in new_workset there is no reason to check further, it will be rerun no matter what
+        # for second_cmd_id in cmds_to_resolve:
+        #     transitive_closure = self.get_transitive_closure_if_can_be_resolved(cmds_to_resolve, [first_cmd_id])
+        for second_cmd_id in sorted(cmds_to_resolve):
+            for first_cmd_id in sorted(self.to_be_resolved[second_cmd_id]):
+                logging.debug(f">>>Checking deps of {second_cmd_id} with {first_cmd_id}")
                 if second_cmd_id not in new_workset:
                     ## If it is None, it means that it has not executed at all,
                     ## so we need to add it in the workset
@@ -260,42 +270,41 @@ class PartialProgramOrder:
                     elif self.has_forward_dependency(first_cmd_id, second_cmd_id):
                         logging.debug(f' > Command {second_cmd_id} was added to the workset, due to a forward dependency with {first_cmd_id}')
                         new_workset.add(second_cmd_id)
-        logging.debug(f"New workset after examining nodes {cmds_to_resolve} is: {new_workset}")
-        logging.debug(" --- Done with dependency resolution --- ")
-        
-        old_speculated = self.speculated.copy()
+        logging.debug(f">>>>>>>{new_workset}")
 
-        self.speculated = {cmd_id for cmd_id in cmds_to_resolve if cmd_id not in new_workset and cmd_id not in self.frontier}
         logging.debug(" > Modifying speculated set accordingly")
+        old_speculated = self.speculated.copy()
+        self.speculated = {cmd_id for cmd_id in cmds_to_resolve if cmd_id not in new_workset and cmd_id not in self.frontier}
         # Set the new workset
         logging.debug(" > Modifying workset accordingly")
 
         self.workset = [cmd_id for cmd_id in self.workset if cmd_id not in cmds_to_resolve]
         self.workset.extend((list(new_workset)))
-        self.workset = [cmd_id for cmd_id in self.workset if cmd_id not in cmds_to_resolve]
-        self.workset.extend((list(new_workset)))
         
         old_committed = self.committed.copy()
         old_frontier = self.frontier.copy()
-        
-        self.step_forward(old_speculated)
+        logging.debug(self.workset)
+        logging.debug(self.get_currently_executing())
+        logging.debug(self.frontier)
+        self.step_forward(old_speculated, old_committed)
         self.log_partial_program_order_info()
 
         logging.debug(f"Commands checked this cycle: {sorted(cmds_to_resolve)}")
         logging.debug(f"Workset    old: {old_workset}")
         logging.debug(f"Workset    new: {self.workset}")
         logging.debug(f"Speculated old: {old_speculated}")
-        logging.debug(f"Speculated new: {self.committed}")
+        logging.debug(f"Speculated new: {self.speculated}")
         logging.debug(f"Committed  old: {old_committed}")
         logging.debug(f"Committed  new: {self.committed}")
         logging.debug(f"Frontier   old: {old_frontier}")
         logging.debug(f"Frontier   new: {self.frontier}")
 
-    def step_forward(self, old_speculated):
+    def step_forward(self, old_speculated, old_committed):
         logging.debug(" > Committing frontier")
         self.commit_frontier()
         logging.debug(" > Moving frontier forward")
         self.move_frontier_forward(old_speculated)
+        self.populate_to_be_resolved_dict(old_committed)
 
     # Add frontier commands to committed set
     def commit_frontier(self):
@@ -305,24 +314,36 @@ class PartialProgramOrder:
     def move_frontier_forward(self, old_speculated: set):
         new_frontier = []
         for node in self.frontier:
-            new_frontier.extend(self.get_next_non_speculated(node, old_speculated))
+            if node not in self.workset: 
+                new_frontier.extend(self.get_next_non_speculated(node, old_speculated))
+            # If node is being executed again, we cannot progress further
+            else:
+                new_frontier.extend([node])
         
         self.frontier = new_frontier
         # self.frontier.node.extend(new_frontier)
 
     def get_next_non_speculated(self, start, old_speculated: set):
             traversal_workset = self.get_next(start)
+            # next_non_speculated = set(self.get_next(start))
             next_non_speculated = []
             while len(traversal_workset) > 0:
                 node_id = traversal_workset.pop()
+            
                 if node_id in old_speculated.union(self.speculated):
+                    assert(node_id not in self.workset)
                     logging.debug(f"Committing speculated node: {node_id}")
                     self.speculated.discard(node_id)
                     self.committed.add(node_id)
                     traversal_workset.extend(self.get_next(node_id))
+                # elif node_id in self.workset:
+                #     self.speculated.discard(node_id)
                 else:
                     next_non_speculated.append(node_id)
-            return next_non_speculated
+                
+
+
+            return list(next_non_speculated)
   
     def has_forward_dependency(self, first_id, second_id):
         first_write_set = set(self.rw_sets[first_id].get_write_set())
@@ -341,26 +362,17 @@ class PartialProgramOrder:
 
     ## TODO: Eventually, in the future, let's add here some form of limit
     def schedule_work(self, limit=0):
-        if len(self.workset) > 0:
-            self.run_all_frontier_cmds()
-            self.schedule_all_workset_non_frontier_cmds()
-        ## TODO: Use the partial order object to pick a few commands (for start let's do all)
-        ##       and run them using the scheduler.
-        ##
-        ## TODO: When scheduling commands, run them with subprocess.run and make sure that at the end
-        ##       they will try to connect to our scheduler socket $PASH_SPEC_SCHEDULER_SOCKET to let us
-        ##       know that they are done.
-        else:
-            logging.debug("Workset is empty, nothing to be scheduled")
-        pass
+        self.run_all_frontier_cmds()
+        self.schedule_all_workset_non_frontier_cmds()
+        # Use the partial order object to pick a few commands (for start let's do all)
+        # and run them using the scheduler.
 
     def schedule_all_workset_non_frontier_cmds(self):
         non_frontier_ids = [node_id for node_id in self.get_workset() 
                             if not self.is_frontier(node_id)]
         for cmd_id in non_frontier_ids:
             # We also need for a cmd to not be waiting to be resolved.
-            logging.debug(f">> Commands to speculatively execute: {[cmd_id for cmd_id in self.commands_currently_executing if cmd_id not in self.to_be_resolved]}")
-            if not cmd_id in self.commands_currently_executing and not cmd_id in self.to_be_resolved:
+            if not cmd_id in self.commands_currently_executing and not cmd_id in self.waiting_to_be_resolved:
                 self.speculate_cmd_non_blocking(cmd_id)
 
     def run_all_frontier_cmds(self):
@@ -424,8 +436,40 @@ class PartialProgramOrder:
         logging.debug(f"FRONTIER:   {self.get_frontier()}")
         logging.debug(f"SPECULATED: {self.get_speculated()}")
         logging.debug(f"EXECUTING:  {list(self.commands_currently_executing.keys())}")
-        logging.debug(f"WAITING:    {sorted(list(self.to_be_resolved))}")
+        logging.debug(f"WAITING:    {sorted(list(self.waiting_to_be_resolved))}")
         logging.debug(f"=" * 60)
+
+
+    def populate_to_be_resolved_dict(self, old_committed):
+        for node_id in self.nodes:
+            if node_id in self.committed:
+                self.to_be_resolved[node_id] = []
+                continue
+            elif node_id in self.waiting_to_be_resolved or node_id in self.get_currently_executing():
+                logging.debug(f"Node {node_id} waiting/executing")
+                continue
+            else:
+                self.to_be_resolved[node_id] = []
+                traversal = []
+                if node_id not in old_committed:
+                    to_add = self.inverse_adjacency[node_id].copy()
+                    traversal = to_add.copy()
+                    to_be_resolved_nodes_ids = to_add.copy()
+                while len(traversal) > 0:
+                    current_node_id = traversal.pop(0)
+                    if current_node_id not in old_committed:
+                        to_add = self.inverse_adjacency[current_node_id]
+                        to_be_resolved_nodes_ids.extend(to_add)
+                        traversal.extend(to_add)
+                    logging.debug(f"{current_node_id}")
+                logging.debug(f"{to_be_resolved_nodes_ids}, {old_committed}<<<<")
+                self.to_be_resolved[node_id] = to_be_resolved_nodes_ids.copy()
+                self.to_be_resolved[node_id] = list(set(self.to_be_resolved[node_id]) - set(old_committed))
+        logging.debug(f"________{self.to_be_resolved}_________{old_committed}")
+
+
+
+
 
     def get_currently_executing(self) -> list:
         return sorted(list(self.commands_currently_executing.keys()))
@@ -471,3 +515,4 @@ def parse_partial_program_order_from_file(file_path: str) -> PartialProgramOrder
         edges[from_id].append(to_id)
     
     return PartialProgramOrder(nodes, edges)
+

--- a/parallel-orch/partial_program_order.py
+++ b/parallel-orch/partial_program_order.py
@@ -253,7 +253,6 @@ class PartialProgramOrder:
         #     transitive_closure = self.get_transitive_closure_if_can_be_resolved(cmds_to_resolve, [first_cmd_id])
         for second_cmd_id in sorted(cmds_to_resolve):
             for first_cmd_id in sorted(self.to_be_resolved[second_cmd_id]):
-                logging.debug(f">>>Checking deps of {second_cmd_id} with {first_cmd_id}")
                 if second_cmd_id not in new_workset:
                     ## If it is None, it means that it has not executed at all,
                     ## so we need to add it in the workset
@@ -270,7 +269,6 @@ class PartialProgramOrder:
                     elif self.has_forward_dependency(first_cmd_id, second_cmd_id):
                         logging.debug(f' > Command {second_cmd_id} was added to the workset, due to a forward dependency with {first_cmd_id}')
                         new_workset.add(second_cmd_id)
-        logging.debug(f">>>>>>>{new_workset}")
 
         logging.debug(" > Modifying speculated set accordingly")
         old_speculated = self.speculated.copy()
@@ -437,6 +435,7 @@ class PartialProgramOrder:
         logging.debug(f"SPECULATED: {self.get_speculated()}")
         logging.debug(f"EXECUTING:  {list(self.commands_currently_executing.keys())}")
         logging.debug(f"WAITING:    {sorted(list(self.waiting_to_be_resolved))}")
+        logging.debug(f"TO RESOLVE: {}")
         logging.debug(f"=" * 60)
 
 
@@ -465,7 +464,7 @@ class PartialProgramOrder:
                 logging.debug(f"{to_be_resolved_nodes_ids}, {old_committed}<<<<")
                 self.to_be_resolved[node_id] = to_be_resolved_nodes_ids.copy()
                 self.to_be_resolved[node_id] = list(set(self.to_be_resolved[node_id]) - set(old_committed))
-        logging.debug(f"________{self.to_be_resolved}_________{old_committed}")
+        
 
 
 

--- a/parallel-orch/partial_program_order.py
+++ b/parallel-orch/partial_program_order.py
@@ -241,6 +241,13 @@ class PartialProgramOrder:
                 next_non_speculated.append(node_id)
         return next_non_speculated
     
+    def run_all_frontier_cmds(self):
+        logging.debug("Starting execution on the whole frontier")
+        cmd_ids = self.get_frontier()
+        for cmd_id in cmd_ids:
+            if not cmd_id in self.commands_currently_executing:
+                self.run_cmd_non_blocking(cmd_id)
+
     ## Run a command and add it to the dictionary of executing ones
     def run_cmd_non_blocking(self, node_id: int):
         ## TODO: A command should only be run if it's in the frontier, otherwise it should be spec run
@@ -248,12 +255,12 @@ class PartialProgramOrder:
         node = self.get_node(node_id)
         cmd = node.get_cmd()
         logging.debug(f'Running command: {node_id} {self.get_node(node_id)}')
-        _proc, trace_file = executor.async_run_and_trace_command_return_trace(cmd, node_id)
+        proc, trace_file = executor.async_run_and_trace_command_return_trace(cmd, node_id)
         logging.debug(f'Read trace from: {trace_file}')
-        self.commands_currently_executing[node_id] = trace_file
+        self.commands_currently_executing[node_id] = (proc, trace_file)
 
     def command_execution_completed(self, node_id: int):
-        trace_file = self.commands_currently_executing.pop(node_id)
+        _proc, trace_file = self.commands_currently_executing.pop(node_id)
         trace_object = executor.read_trace(trace_file)
         # print(trace_object)
         read_set, write_set = trace.parse_and_gather_cmd_rw_sets(trace_object)

--- a/parallel-orch/partial_program_order.py
+++ b/parallel-orch/partial_program_order.py
@@ -284,6 +284,9 @@ class PartialProgramOrder:
         logging.debug(self.workset)
         logging.debug(self.get_currently_executing())
         logging.debug(self.frontier)
+
+        # TODO: ideally move this to the point 
+        #       we start executing a new command
         self.step_forward(old_speculated, old_committed)
         self.log_partial_program_order_info()
 
@@ -453,12 +456,8 @@ class PartialProgramOrder:
                         traversal.extend(to_add)
                 self.to_be_resolved[node_id] = to_be_resolved_nodes_ids.copy()
                 self.to_be_resolved[node_id] = list(set(self.to_be_resolved[node_id]) - set(old_committed))
+
         
-
-
-
-
-
     def get_currently_executing(self) -> list:
         return sorted(list(self.commands_currently_executing.keys()))
 

--- a/parallel-orch/partial_program_order.py
+++ b/parallel-orch/partial_program_order.py
@@ -338,9 +338,6 @@ class PartialProgramOrder:
                 #     self.speculated.discard(node_id)
                 else:
                     next_non_speculated.append(node_id)
-                
-
-
             return list(next_non_speculated)
   
     def has_forward_dependency(self, first_id, second_id):
@@ -362,8 +359,6 @@ class PartialProgramOrder:
     def schedule_work(self, limit=0):
         self.run_all_frontier_cmds()
         self.schedule_all_workset_non_frontier_cmds()
-        # Use the partial order object to pick a few commands (for start let's do all)
-        # and run them using the scheduler.
 
     def schedule_all_workset_non_frontier_cmds(self):
         non_frontier_ids = [node_id for node_id in self.get_workset() 
@@ -406,12 +401,8 @@ class PartialProgramOrder:
         read_set, write_set = trace.parse_and_gather_cmd_rw_sets(trace_object)
         rw_set = RWSet(read_set, write_set)
         self.update_rw_set(node_id, rw_set)
-
-        ## TODO: Maybe we can just resolve dependencies of a single command and not the whole workset.
         logging.debug(f" --- Node {node_id}, just finished execution ---")
-        # self.log_partial_program_order_info()
         self.resolve_dependencies_continuous(node_id)
-        # self.log_partial_program_order_info()
 
     def log_rw_sets(self, logging):
         logging.debug("====== |RW Sets| ======")
@@ -428,24 +419,24 @@ class PartialProgramOrder:
             logging.debug(f"Write: {len(rw_set.get_write_set()) if rw_set is not None else None}")
 
     def log_partial_program_order_info(self):
-        logging.debug(f"=" * 60)
-        logging.debug(f"WORKSET:    {self.get_workset()}")
-        logging.debug(f"COMMITTED:  {self.get_committed()}")
-        logging.debug(f"FRONTIER:   {self.get_frontier()}")
-        logging.debug(f"SPECULATED: {self.get_speculated()}")
-        logging.debug(f"EXECUTING:  {list(self.commands_currently_executing.keys())}")
-        logging.debug(f"WAITING:    {sorted(list(self.waiting_to_be_resolved))}")
-        logging.debug(f"TO RESOLVE: {}")
-        logging.debug(f"=" * 60)
-
+        logging.debug(f"=" * 80)
+        logging.debug(f"WORKSET:        {self.get_workset()}")
+        logging.debug(f"COMMITTED:      {self.get_committed()}")
+        logging.debug(f"FRONTIER:       {self.get_frontier()}")
+        logging.debug(f"SPECULATED:     {self.get_speculated()}")
+        logging.debug(f"EXECUTING:      {list(self.commands_currently_executing.keys())}")
+        logging.debug(f"WAITING:        {sorted(list(self.waiting_to_be_resolved))}")
+        logging.debug(f"TO RESOLVE:     {self.to_be_resolved}")
+        logging.debug(f"=" * 80)
 
     def populate_to_be_resolved_dict(self, old_committed):
         for node_id in self.nodes:
             if node_id in self.committed:
                 self.to_be_resolved[node_id] = []
                 continue
+            # We don't want to modify the set of nodes to check for dependencies for this node
+            # as it started running before previous cmds had started executing
             elif node_id in self.waiting_to_be_resolved or node_id in self.get_currently_executing():
-                logging.debug(f"Node {node_id} waiting/executing")
                 continue
             else:
                 self.to_be_resolved[node_id] = []
@@ -460,8 +451,6 @@ class PartialProgramOrder:
                         to_add = self.inverse_adjacency[current_node_id]
                         to_be_resolved_nodes_ids.extend(to_add)
                         traversal.extend(to_add)
-                    logging.debug(f"{current_node_id}")
-                logging.debug(f"{to_be_resolved_nodes_ids}, {old_committed}<<<<")
                 self.to_be_resolved[node_id] = to_be_resolved_nodes_ids.copy()
                 self.to_be_resolved[node_id] = list(set(self.to_be_resolved[node_id]) - set(old_committed))
         

--- a/parallel-orch/partial_program_order.py
+++ b/parallel-orch/partial_program_order.py
@@ -180,37 +180,36 @@ class PartialProgramOrder:
         assert(False)
 
 
-    # If the cmd id is less than
-    def can_be_resolved(self, node_id: int) -> bool:
-        logging.debug(f"Examining if can be resolved: {node_id}, {self.get_currently_executing()}")
+    # Check if the specific command can be resolved.
+    # TODO: this does not truly follow partial program order, we should implement it correctly
+    def cmd_can_be_resolved(self, node_id: int) -> bool:
+        # If the command we evaluate has no earlier command currently executing, it can be resolved this round
         if len(self.get_currently_executing()) > 0:
             return node_id < min(self.get_currently_executing())
         else:
             return True
-
-
+    
     def find_cmds_to_resolve(self, cmd_ids_to_check: list):
         cmds_to_resolve = []
-        logging.debug(f"Cmds to check: {cmd_ids_to_check}")
+        logging.debug(f" > Uncommitted commands done executing to be checked: {cmd_ids_to_check}")
         for cmd_id in cmd_ids_to_check:
             # We check if we can resolve any possible dependencies
             # If we can't, we have to wait for another cycle
-            if not self.can_be_resolved(cmd_id):
+            if not self.cmd_can_be_resolved(cmd_id):
                 if cmd_id not in self.to_be_resolved:
-                    logging.debug(f"> Adding node {cmd_id} to waiting list")
+                    logging.debug(f" > Adding node {cmd_id} to waiting list")
                     self.to_be_resolved.add(cmd_id)
                 else:
-                    logging.debug(f"> Keeping node {cmd_id} to waiting list")
+                    logging.debug(f" > Keeping node {cmd_id} to waiting list")
             # If we are in this branch it means that we can resolve the dependencies of the current command
             else:
                 cmds_to_resolve.append(cmd_id)
                 # We remove the command from the waiting to be resolved set
                 if cmd_id in self.to_be_resolved:
-                    logging.debug(f"> Removing node {cmd_id} from waiting list")
+                    logging.debug(f" > Removing node {cmd_id} from waiting list")
                     self.to_be_resolved.remove(cmd_id)
                 else:
-                    logging.debug(f"> Node {cmd_id} is able to be resolved")
-        logging.debug(sorted(cmds_to_resolve))
+                    logging.debug(f" > Node {cmd_id} is able to be resolved")
         return sorted(cmds_to_resolve)
 
 
@@ -220,52 +219,82 @@ class PartialProgramOrder:
     def resolve_dependencies_continuous(self, new_node_id):
         # We want to check every single command that has already finished executing but
         # not yet able to be resolved
+        logging.debug("Finding sets of commands that can be resolved after {new_node_id} finished executing")
         cmds_to_resolve = self.find_cmds_to_resolve(sorted(list(self.to_be_resolved.union({new_node_id}))))
-        # If no commands can be resolved this round, do nothing and wait until a new command finishes executing
-        if len(cmds_to_resolve) == 0:
-            logging.debug("No resolvable nodes were found in this iteration")
-            return
+        logging.debug(f"Commands to check for dependencies this round are:  {sorted(cmds_to_resolve)}")
+        logging.debug(f"Commands that can not be resolved this round are:   {sorted(self.to_be_resolved)}")
         
+        # If no commands can be resolved this round, 
+        # do nothing and wait until a new command finishes executing
+        if len(cmds_to_resolve) == 0:
+            logging.debug("No resolvable nodes were found in this round, nothing will change...")
+            return
+
+        # Init stuff
         independent_cmds_this_cycle = set(cmds_to_resolve)
-        # This doesn't work for true partial program order
-        # TODO: use get_transitive_closure()
         new_workset = set()
+        old_workset = self.workset.copy()
+        logging.debug(" --- Starting dependency resolution --- ")
+        logging.debug(f"Commands to be checked for dependencies: {sorted(cmds_to_resolve)}")
         for first_cmd_id in cmds_to_resolve:
             # We don't want the first cmd, so we remove it from the transitive closure.
             transitive_closure = self.get_transitive_closure_if_can_be_resolved(cmds_to_resolve, [first_cmd_id])
             transitive_closure.remove(first_cmd_id)
-            logging.debug(f">>>>>>>{first_cmd_id}, {transitive_closure}")
+            logging.debug(f" > Resolvable transitive closure for node {first_cmd_id} is: {transitive_closure}")
             # We look at the transitive closure instead of workset because we want to also check the speculated cmds that are not in the workset
             for second_cmd_id in transitive_closure:
-                # If no anti-dependencies exist, we proceed to check for dependencies
-                ## TODO: We need to keep track of invalidations continuously, which is non trivial!
+                # If cmd already in new_workset there is no reason to check further, it will be rerun no matter what
                 if second_cmd_id not in new_workset:
                     ## If it is None, it means that it has not executed at all,
                     ## so we need to add it in the workset
+                    ## TODO: Check for overwork
                     if self.get_rw_set(second_cmd_id) is None:
-                        ## TODO: Check if this could lead to overwork
-                        logging.debug(f'Command: {second_cmd_id} was added to the workset, because it was never executed before')
+                        logging.debug(f' > Command: {second_cmd_id} was added to the workset, because it was never executed before')
                         new_workset.add(second_cmd_id)
-                    elif self.has_backward_dependency(first_cmd_id, second_cmd_id) or self.has_write_dependency(first_cmd_id, second_cmd_id) or self.has_forward_dependency(first_cmd_id, second_cmd_id):
-                        ## TODO: make the logging more precise, what type of dependency
-                        ## TODO: Check for overwork
-                        logging.debug(f'Command: {second_cmd_id} was added to the workset, due to a dependency')
+                    elif self.has_backward_dependency(first_cmd_id, second_cmd_id):
+                        logging.debug(f' > Command {second_cmd_id} was added to the workset, due to a backward dependency with {first_cmd_id}')
                         new_workset.add(second_cmd_id)
-        logging.debug(f"Workset from examining nodes {cmds_to_resolve} is: {new_workset}")
-
+                    elif self.has_write_dependency(first_cmd_id, second_cmd_id):
+                        logging.debug(f' > Command {second_cmd_id} was added to the workset, due to a write dependency with {first_cmd_id}')
+                        new_workset.add(second_cmd_id)
+                    elif self.has_forward_dependency(first_cmd_id, second_cmd_id):
+                        logging.debug(f' > Command {second_cmd_id} was added to the workset, due to a forward dependency with {first_cmd_id}')
+                        new_workset.add(second_cmd_id)
+        logging.debug(f"New workset after examining nodes {cmds_to_resolve} is: {new_workset}")
+        logging.debug(" --- Done with dependency resolution --- ")
+        
         old_speculated = self.speculated.copy()
+
         self.speculated = {cmd_id for cmd_id in cmds_to_resolve if cmd_id not in new_workset and cmd_id not in self.frontier}
+        logging.debug(" > Modifying speculated set accordingly")
         # Set the new workset
-        self.log_partial_program_order_info()
+        logging.debug(" > Modifying workset accordingly")
+
         self.workset = [cmd_id for cmd_id in self.workset if cmd_id not in cmds_to_resolve]
         self.workset.extend((list(new_workset)))
-        self.log_partial_program_order_info()
-        logging.debug("-")
+        self.workset = [cmd_id for cmd_id in self.workset if cmd_id not in cmds_to_resolve]
+        self.workset.extend((list(new_workset)))
+        
+        old_committed = self.committed.copy()
+        old_frontier = self.frontier.copy()
+        
         self.step_forward(old_speculated)
         self.log_partial_program_order_info()
 
+        logging.debug(f"Commands checked this cycle: {sorted(cmds_to_resolve)}")
+        logging.debug(f"Workset    old: {old_workset}")
+        logging.debug(f"Workset    new: {self.workset}")
+        logging.debug(f"Speculated old: {old_speculated}")
+        logging.debug(f"Speculated new: {self.committed}")
+        logging.debug(f"Committed  old: {old_committed}")
+        logging.debug(f"Committed  new: {self.committed}")
+        logging.debug(f"Frontier   old: {old_frontier}")
+        logging.debug(f"Frontier   new: {self.frontier}")
+
     def step_forward(self, old_speculated):
+        logging.debug(" > Committing frontier")
         self.commit_frontier()
+        logging.debug(" > Moving frontier forward")
         self.move_frontier_forward(old_speculated)
 
     # Add frontier commands to committed set
@@ -312,14 +341,17 @@ class PartialProgramOrder:
 
     ## TODO: Eventually, in the future, let's add here some form of limit
     def schedule_work(self, limit=0):
-        self.run_all_frontier_cmds()
-        self.schedule_all_workset_non_frontier_cmds()
+        if len(self.workset) > 0:
+            self.run_all_frontier_cmds()
+            self.schedule_all_workset_non_frontier_cmds()
         ## TODO: Use the partial order object to pick a few commands (for start let's do all)
         ##       and run them using the scheduler.
         ##
         ## TODO: When scheduling commands, run them with subprocess.run and make sure that at the end
         ##       they will try to connect to our scheduler socket $PASH_SPEC_SCHEDULER_SOCKET to let us
         ##       know that they are done.
+        else:
+            logging.debug("Workset is empty, nothing to be scheduled")
         pass
 
     def schedule_all_workset_non_frontier_cmds(self):
@@ -327,6 +359,7 @@ class PartialProgramOrder:
                             if not self.is_frontier(node_id)]
         for cmd_id in non_frontier_ids:
             # We also need for a cmd to not be waiting to be resolved.
+            logging.debug(f">> Commands to speculatively execute: {[cmd_id for cmd_id in self.commands_currently_executing if cmd_id not in self.to_be_resolved]}")
             if not cmd_id in self.commands_currently_executing and not cmd_id in self.to_be_resolved:
                 self.speculate_cmd_non_blocking(cmd_id)
 
@@ -365,11 +398,10 @@ class PartialProgramOrder:
         self.update_rw_set(node_id, rw_set)
 
         ## TODO: Maybe we can just resolve dependencies of a single command and not the whole workset.
-        logging.debug(f"Node to be examined ----> {node_id}")
-        self.log_partial_program_order_info()
+        logging.debug(f" --- Node {node_id}, just finished execution ---")
+        # self.log_partial_program_order_info()
         self.resolve_dependencies_continuous(node_id)
-        self.log_partial_program_order_info()
-
+        # self.log_partial_program_order_info()
 
     def log_rw_sets(self, logging):
         logging.debug("====== |RW Sets| ======")
@@ -398,7 +430,6 @@ class PartialProgramOrder:
     def get_currently_executing(self) -> list:
         return sorted(list(self.commands_currently_executing.keys()))
 
-
 def parse_cmd_from_file(file_path: str) -> str:
     with open(file_path) as f:
         cmd = f.read()
@@ -407,7 +438,6 @@ def parse_cmd_from_file(file_path: str) -> str:
 def parse_edge_line(line: str) -> "tuple[int, int]":
     from_str, to_str = line.split(" -> ")
     return (int(from_str), int(to_str))
-    
 
 def parse_partial_program_order_from_file(file_path: str) -> PartialProgramOrder:
     with open(file_path) as f:
@@ -438,7 +468,6 @@ def parse_partial_program_order_from_file(file_path: str) -> PartialProgramOrder
     edges = {i : [] for i in range(number_of_nodes)}
     for edge_line in edge_lines:
         from_id, to_id = parse_edge_line(edge_line)
-        # print("Edge:", from_id, to_id)
         edges[from_id].append(to_id)
     
     return PartialProgramOrder(nodes, edges)

--- a/parallel-orch/partial_program_order.py
+++ b/parallel-orch/partial_program_order.py
@@ -184,8 +184,13 @@ class PartialProgramOrder:
                     ## If it is None, it means that it has not executed at all,
                     ## so we need to add it in the workset
                     if self.get_rw_set(second_cmd_id) is None:
+                        ## TODO: Check if this could lead to overwork
+                        logging.debug(f'Command: {second_cmd_id} was added to the workset, because it was never executed before')
                         new_workset.append(second_cmd_id)
                     elif self.has_backward_dependency(first_cmd_id, second_cmd_id) or self.has_write_dependency(first_cmd_id, second_cmd_id) or self.has_forward_dependency(first_cmd_id, second_cmd_id):
+                        ## TODO: make the logging more precise, what type of dependency
+                        ## TODO: Check for overwork
+                        logging.debug(f'Command: {second_cmd_id} was added to the workset, due to a dependency')
                         new_workset.append(second_cmd_id)                    
         # Set the new speculated set
         
@@ -193,7 +198,7 @@ class PartialProgramOrder:
         self.speculated = {cmd_id for cmd_id in self.workset if cmd_id not in new_workset and cmd_id not in self.frontier}
         # Set the new workset
         self.workset = new_workset
-        self.step_forward(old_speculated)
+        self.step_forward(old_speculated)        
 
     def has_forward_dependency(self, first_id, second_id):
         first_write_set = set(self.rw_sets[first_id].get_write_set())
@@ -241,6 +246,25 @@ class PartialProgramOrder:
                 next_non_speculated.append(node_id)
         return next_non_speculated
     
+    ## TODO: Eventually, in the future, let's add here some form of limit
+    def schedule_work(self, limit=0):
+        self.run_all_frontier_cmds()
+        self.schedule_all_workset_non_frontier_cmds()
+        ## TODO: Use the partial order object to pick a few commands (for start let's do all)
+        ##       and run them using the scheduler.
+        ##
+        ## TODO: When scheduling commands, run them with subprocess.run and make sure that at the end
+        ##       they will try to connect to our scheduler socket $PASH_SPEC_SCHEDULER_SOCKET to let us
+        ##       know that they are done.
+        pass
+
+    def schedule_all_workset_non_frontier_cmds(self):
+        non_frontier_ids = [node_id for node_id in self.get_workset() 
+                            if not self.is_frontier(node_id)]
+        for cmd_id in non_frontier_ids:
+            if not cmd_id in self.commands_currently_executing:
+                self.speculate_cmd_non_blocking(cmd_id)
+
     def run_all_frontier_cmds(self):
         logging.debug("Starting execution on the whole frontier")
         cmd_ids = self.get_frontier()
@@ -250,12 +274,21 @@ class PartialProgramOrder:
 
     ## Run a command and add it to the dictionary of executing ones
     def run_cmd_non_blocking(self, node_id: int):
-        ## TODO: A command should only be run if it's in the frontier, otherwise it should be spec run
+        ## A command should only be run if it's in the frontier, otherwise it should be spec run
         assert(self.is_frontier(node_id))
         node = self.get_node(node_id)
         cmd = node.get_cmd()
         logging.debug(f'Running command: {node_id} {self.get_node(node_id)}')
         proc, trace_file = executor.async_run_and_trace_command_return_trace(cmd, node_id)
+        logging.debug(f'Read trace from: {trace_file}')
+        self.commands_currently_executing[node_id] = (proc, trace_file)
+
+    ## Run a command and add it to the dictionary of executing ones
+    def speculate_cmd_non_blocking(self, node_id: int):
+        node = self.get_node(node_id)
+        cmd = node.get_cmd()
+        logging.debug(f'Speculating command: {node_id} {self.get_node(node_id)}')
+        proc, trace_file = executor.async_run_and_trace_command_return_trace_in_sandbox(cmd, node_id)
         logging.debug(f'Read trace from: {trace_file}')
         self.commands_currently_executing[node_id] = (proc, trace_file)
 
@@ -266,6 +299,8 @@ class PartialProgramOrder:
         read_set, write_set = trace.parse_and_gather_cmd_rw_sets(trace_object)
         rw_set = RWSet(read_set, write_set)
         self.update_rw_set(node_id, rw_set)
+
+        ## TODO: Maybe we can just resolve dependencies of a single command and not the whole workset.
         self.resolve_dependencies()
 
 

--- a/parallel-orch/partial_program_order.py
+++ b/parallel-orch/partial_program_order.py
@@ -205,8 +205,11 @@ class PartialProgramOrder:
             else:
                 cmds_to_resolve.append(cmd_id)
                 # We remove the command from the waiting to be resolved set
-                logging.debug(f"> Removing node {cmd_id} from waiting list")
-                self.to_be_resolved.discard(cmd_id)
+                if cmd_id in self.to_be_resolved:
+                    logging.debug(f"> Removing node {cmd_id} from waiting list")
+                    self.to_be_resolved.remove(cmd_id)
+                else:
+                    logging.debug(f"> Node {cmd_id} is able to be resolved")
         logging.debug(sorted(cmds_to_resolve))
         return sorted(cmds_to_resolve)
 
@@ -215,38 +218,23 @@ class PartialProgramOrder:
     ## Forward dependency is when a command's output is the same
     ## as the input of a following command
     def resolve_dependencies_continuous(self, new_node_id):
-        logging.debug(f"Node to be examined ----> {new_node_id}")
-        self.log_partial_program_order_info()
         # We want to check every single command that has already finished executing but
         # not yet able to be resolved
         cmds_to_resolve = self.find_cmds_to_resolve(sorted(list(self.to_be_resolved.union({new_node_id}))))
         # If no commands can be resolved this round, do nothing and wait until a new command finishes executing
         if len(cmds_to_resolve) == 0:
+            logging.debug("No resolvable nodes were found in this iteration")
             return
         
-        # Commit right away as it is the only command to resolve
-        if len(cmds_to_resolve) == 1:
-            to_commit = cmds_to_resolve.pop()
-            self.committed.add(to_commit)
-            # If cmd exists in speculated it means it should have been resolved 
-            # in a cycle with len(cmds_to_resolve) > 1
-            assert(to_commit not in self.speculated)
-            self.workset.remove(to_commit)
-            # The cmd should also be in the frontier
-            assert(to_commit in self.frontier)
-            self.frontier.remove(to_commit)
-            self.frontier.extend(self.get_next(to_commit))
-            return
-        # If we reach this point, we follow the traditional cycle approach
-        # This will help us determine the new specualted set
         independent_cmds_this_cycle = set(cmds_to_resolve)
         # This doesn't work for true partial program order
         # TODO: use get_transitive_closure()
-        new_workset = {}
+        new_workset = set()
         for first_cmd_id in cmds_to_resolve:
             # We don't want the first cmd, so we remove it from the transitive closure.
             transitive_closure = self.get_transitive_closure_if_can_be_resolved(cmds_to_resolve, [first_cmd_id])
             transitive_closure.remove(first_cmd_id)
+            logging.debug(f">>>>>>>{first_cmd_id}, {transitive_closure}")
             # We look at the transitive closure instead of workset because we want to also check the speculated cmds that are not in the workset
             for second_cmd_id in transitive_closure:
                 # If no anti-dependencies exist, we proceed to check for dependencies
@@ -263,43 +251,48 @@ class PartialProgramOrder:
                         ## TODO: Check for overwork
                         logging.debug(f'Command: {second_cmd_id} was added to the workset, due to a dependency')
                         new_workset.add(second_cmd_id)
-        logging.debug(f"!!!!!!!!!!!!!!!{new_workset}")
+        logging.debug(f"Workset from examining nodes {cmds_to_resolve} is: {new_workset}")
 
         old_speculated = self.speculated.copy()
         self.speculated = {cmd_id for cmd_id in cmds_to_resolve if cmd_id not in new_workset and cmd_id not in self.frontier}
         # Set the new workset
-        self.workset = new_workset
-        self.step_forward_continuous(cmds_to_resolve, old_speculated)
+        self.log_partial_program_order_info()
+        self.workset = [cmd_id for cmd_id in self.workset if cmd_id not in cmds_to_resolve]
+        self.workset.extend((list(new_workset)))
+        self.log_partial_program_order_info()
+        logging.debug("-")
+        self.step_forward(old_speculated)
+        self.log_partial_program_order_info()
 
-    def step_forward(self, old_speculated, cmds_to_resolve):
-        self.commit_frontier(cmds_to_resolve)
-        self.move_frontier_forward(old_speculated, cmds_to_resolve)
+    def step_forward(self, old_speculated):
+        self.commit_frontier()
+        self.move_frontier_forward(old_speculated)
 
     # Add frontier commands to committed set
-    def commit_frontier(self, cmds_to_resolve):
+    def commit_frontier(self):
         # Second condition below may be unecessary
-        self.committed.update({frontier_node for frontier_node in self.frontier in frontier_node in cmds_to_resolve})
+        self.committed.update({frontier_node for frontier_node in self.frontier})
 
-    def move_frontier_node_forward(self, old_speculated: set, cmds_to_resolve: set):
+    def move_frontier_forward(self, old_speculated: set):
         new_frontier = []
         for node in self.frontier:
-            if node in cmds_to_resolve:
-                new_frontier.extend(self.get_next_non_speculated_continuous(node, old_speculated, cmds_to_resolve))
-        self.frontier.discard(node)
-        self.frontier.node.extend(new_frontier)
+            new_frontier.extend(self.get_next_non_speculated(node, old_speculated))
+        
+        self.frontier = new_frontier
+        # self.frontier.node.extend(new_frontier)
 
-    def get_next_non_speculated(self, start, old_speculated: set, cmds_to_resolve):
+    def get_next_non_speculated(self, start, old_speculated: set):
             traversal_workset = self.get_next(start)
             next_non_speculated = []
             while len(traversal_workset) > 0:
                 node_id = traversal_workset.pop()
-                if node_id in cmds_to_resolve:
-                    if node_id in old_speculated.union(self.speculated):
-                        self.speculated.discard(node_id)
-                        self.committed.add(node_id)
-                        traversal_workset.extend(self.get_next(node_id))
-                    else:
-                        next_non_speculated.append(node_id)
+                if node_id in old_speculated.union(self.speculated):
+                    logging.debug(f"Committing speculated node: {node_id}")
+                    self.speculated.discard(node_id)
+                    self.committed.add(node_id)
+                    traversal_workset.extend(self.get_next(node_id))
+                else:
+                    next_non_speculated.append(node_id)
             return next_non_speculated
   
     def has_forward_dependency(self, first_id, second_id):
@@ -333,7 +326,8 @@ class PartialProgramOrder:
         non_frontier_ids = [node_id for node_id in self.get_workset() 
                             if not self.is_frontier(node_id)]
         for cmd_id in non_frontier_ids:
-            if not cmd_id in self.commands_currently_executing:
+            # We also need for a cmd to not be waiting to be resolved.
+            if not cmd_id in self.commands_currently_executing and not cmd_id in self.to_be_resolved:
                 self.speculate_cmd_non_blocking(cmd_id)
 
     def run_all_frontier_cmds(self):
@@ -371,7 +365,10 @@ class PartialProgramOrder:
         self.update_rw_set(node_id, rw_set)
 
         ## TODO: Maybe we can just resolve dependencies of a single command and not the whole workset.
+        logging.debug(f"Node to be examined ----> {node_id}")
+        self.log_partial_program_order_info()
         self.resolve_dependencies_continuous(node_id)
+        self.log_partial_program_order_info()
 
 
     def log_rw_sets(self, logging):

--- a/parallel-orch/scheduler_server.py
+++ b/parallel-orch/scheduler_server.py
@@ -89,15 +89,13 @@ class Scheduler:
         logging.debug(f'Scheduler: Received wait for node_id: {node_id}')
         
         ## If the node_id is already committed, just return its exit code
-        # if node_id in self.partial_program_order.get_committed():
-
-        ## TODO: If the node_id is already committed, just return its exit code
-        ##       Else, add this wait to self.waiting_for_response
-
-        ## Command has not executed yet, so we need to wait for it
-        self.waiting_for_response[node_id] = connection
-
-        self.partial_program_order.run_cmd_non_blocking(node_id)
+        if node_id in self.partial_program_order.get_committed():
+            logging.debug(f'Node: {node_id} found in committed, responding immediately!')
+            self.respond_to_pending_wait(node_id, 0)
+        else:
+            ## Command has not executed yet, so we need to wait for it
+            logging.debug(f'Node: {node_id} has not finished execution, waiting for response...')
+            self.waiting_for_response[node_id] = connection
 
 
     def __parse_command_exec_complete(self, input_cmd: str) -> "tuple[int, int]":
@@ -108,6 +106,12 @@ class Scheduler:
             return command_id, exit_code
         except:
             raise Exception(f'Parsing failure for line: {input_cmd}')
+
+    def respond_to_pending_wait(self, node_id: int, exit_code: int):
+        assert(node_id in self.waiting_for_response)
+        connection = self.waiting_for_response.pop(node_id)
+        socket_respond(connection, success_response(exit_code))
+        connection.close()
 
     def handle_command_exec_complete(self, input_cmd: str):
         assert(input_cmd.startswith("CommandExecComplete:"))
@@ -123,9 +127,7 @@ class Scheduler:
         
         ## If there is a connection waiting for this node_id, respond to it
         if cmd_id in self.waiting_for_response:
-            connection = self.waiting_for_response.pop(cmd_id)
-            socket_respond(connection, success_response(exit_code))
-            connection.close()
+            self.respond_to_pending_wait(cmd_id, exit_code)
 
     def process_next_cmd(self):
         connection, input_cmd = socket_get_next_cmd(self.socket)
@@ -169,6 +171,7 @@ class Scheduler:
     ## It should add some work (if possible), and then return immediately.
     ## It is called once per loop iteration, making sure that there is always work happening
     def schedule_work(self):
+        self.partial_program_order.run_all_frontier_cmds()
         ## TODO: Use the partial order object to pick a few commands (for start let's do all)
         ##       and run them using the scheduler.
         ##

--- a/parallel-orch/scheduler_server.py
+++ b/parallel-orch/scheduler_server.py
@@ -187,14 +187,14 @@ class Scheduler:
         
 
         while not self.done:
-            ## Scheduler some work (if we are already at capacity this will return immediately)
+            ## Schedule some work (if we are already at capacity this will return immediately)
             self.schedule_work()
+            ## Process a single request
+            self.process_next_cmd()
+            # If workset is empty we should end.
+            # TODO: ec checks fail for now
             if len(self.partial_program_order.workset) == 0:
-                logging.debug("Workset is empty, nothing to be scheduled")
-                exit()
-            else:
-                ## Process a single request
-                self.process_next_cmd()
+                self.done = True
 
         
         self.socket.close()

--- a/parallel-orch/scheduler_server.py
+++ b/parallel-orch/scheduler_server.py
@@ -80,7 +80,7 @@ class Scheduler:
         self.partial_program_order.init_workset()
         logging.debug(f'Parsed partial program order:')
         self.partial_program_order.log_partial_program_order_info()
-        self.partial_program_order.populate_to_be_resolved_dict()
+        self.partial_program_order.populate_to_be_resolved_dict([])
         logging.debug(f'To be resolved sets per node:')
         logging.debug(self.partial_program_order.to_be_resolved)
 
@@ -189,9 +189,12 @@ class Scheduler:
         while not self.done:
             ## Scheduler some work (if we are already at capacity this will return immediately)
             self.schedule_work()
-
-            ## Process a single request
-            self.process_next_cmd()
+            if len(self.partial_program_order.workset) == 0:
+                logging.debug("Workset is empty, nothing to be scheduled")
+                exit()
+            else:
+                ## Process a single request
+                self.process_next_cmd()
 
         
         self.socket.close()

--- a/parallel-orch/scheduler_server.py
+++ b/parallel-orch/scheduler_server.py
@@ -79,7 +79,7 @@ class Scheduler:
         self.partial_program_order = parse_partial_program_order_from_file(partial_order_file)
         self.partial_program_order.init_workset()
         logging.debug(f'Parsed partial program order:')
-        self.partial_program_order.log_partial_program_order_info()
+        # self.partial_program_order.log_partial_program_order_info()
 
     def handle_wait(self, input_cmd: str, connection):
         assert(input_cmd.startswith("Wait"))
@@ -123,7 +123,7 @@ class Scheduler:
         ## Gather RWset, resolve dependencies, and progress graph
         self.partial_program_order.command_execution_completed(cmd_id)
         
-        self.partial_program_order.log_partial_program_order_info()
+        # self.partial_program_order.log_partial_program_order_info()
         
         ## If there is a connection waiting for this node_id, respond to it
         if cmd_id in self.waiting_for_response:

--- a/parallel-orch/scheduler_server.py
+++ b/parallel-orch/scheduler_server.py
@@ -79,7 +79,10 @@ class Scheduler:
         self.partial_program_order = parse_partial_program_order_from_file(partial_order_file)
         self.partial_program_order.init_workset()
         logging.debug(f'Parsed partial program order:')
-        # self.partial_program_order.log_partial_program_order_info()
+        self.partial_program_order.log_partial_program_order_info()
+        self.partial_program_order.populate_to_be_resolved_dict()
+        logging.debug(f'To be resolved sets per node:')
+        logging.debug(self.partial_program_order.to_be_resolved)
 
     def handle_wait(self, input_cmd: str, connection):
         assert(input_cmd.startswith("Wait"))
@@ -91,7 +94,9 @@ class Scheduler:
         ## If the node_id is already committed, just return its exit code
         if node_id in self.partial_program_order.get_committed():
             logging.debug(f'Node: {node_id} found in committed, responding immediately!')
+            self.waiting_for_response[node_id] = connection
             self.respond_to_pending_wait(node_id, 0)
+            
         else:
             ## Command has not executed yet, so we need to wait for it
             logging.debug(f'Node: {node_id} has not finished execution, waiting for response...')

--- a/parallel-orch/scheduler_server.py
+++ b/parallel-orch/scheduler_server.py
@@ -171,14 +171,7 @@ class Scheduler:
     ## It should add some work (if possible), and then return immediately.
     ## It is called once per loop iteration, making sure that there is always work happening
     def schedule_work(self):
-        self.partial_program_order.run_all_frontier_cmds()
-        ## TODO: Use the partial order object to pick a few commands (for start let's do all)
-        ##       and run them using the scheduler.
-        ##
-        ## TODO: When scheduling commands, run them with subprocess.run and make sure that at the end
-        ##       they will try to connect to our scheduler socket $PASH_SPEC_SCHEDULER_SOCKET to let us
-        ##       know that they are done.
-        pass
+        self.partial_program_order.schedule_work()
 
     def run(self):
         ## The first command should be the daemon start


### PR DESCRIPTION
This PR modifies the scheduler to be event-driven and continuous. It currently works if the scheduling policy is conservative (only run frontier) but it doesn't work if there is any speculation since resolving dependencies has to happen incrmentally now.

The scheduler is now broken, so we need to go back to the drawing table to redesign the scheduling algorithm without steps!!!

