### PR TITLE
Support break and continue

### DIFF
--- a/parallel-orch/analysis.py
+++ b/parallel-orch/analysis.py
@@ -1,16 +1,16 @@
 import logging
 
+import libdash.parser
 from shasta.ast_node import *
 from shasta.json_to_ast import to_ast_node
-
-import libdash.parser
+from sh_expand import expand
 
 ## Keeps track of the first time we call the parser
 first_time_calling_parser = True
 
 ## Parses straight a shell script to an AST
 ## through python without calling it as an executable
-def parse_shell_to_asts(input_script_path):
+def parse_shell_to_asts(input_script_path) -> "list[AstNode]":
     global first_time_calling_parser
 
     try:
@@ -21,9 +21,9 @@ def parse_shell_to_asts(input_script_path):
 
         ## Transform the untyped ast objects to typed ones
         typed_ast_objects = []
-        for untyped_ast, original_text, linno_before, linno_after, in new_ast_objects:
+        for untyped_ast, _original_text, _linno_before, _linno_after, in new_ast_objects:
              typed_ast = to_ast_node(untyped_ast)
-             typed_ast_objects.append((typed_ast, original_text, linno_before, linno_after))
+             typed_ast_objects.append(typed_ast)
 
         return typed_ast_objects
     except libdash.parser.ParsingException as e:
@@ -33,22 +33,98 @@ def parse_shell_to_asts(input_script_path):
 
 ## Returns true if the script is safe to speculate and execute outside
 ##  of the original shell context.
-def safe_to_execute(asts) -> bool:
-    logging.debug(f'Asts in question: {asts}')
+##
+## The script is not safe if it might contain a shell primitive. Therefore
+##  the analysis checks if the command in question is one of the underlying
+##  shell's primitives (in our case bash) and if so returns False
+def safe_to_execute(asts: "list[AstNode]", variables: dict) -> bool:
+    ## There should always be a single AST per node and it must be a command
+    assert(len(asts) == 1)
+    ast = asts[0]
+    assert(isinstance(ast, CommandNode))
+    logging.debug(f'Ast in question: {ast}')
     ## TODO: Expand and check whether the asts contain
     ##  a command substitution or a primitive.
     ## If so, then we need to tell the original script to execute the command.
-    ##
-    ## TODO: Write my analysis here, then move it to expand, 
-    ##       and then move expand to its own library
-    ##
-    ## TODO: Also, add a test with a break and see it fail
-    
-    ## TODO: Push the changes that modify the tests to show stderr incrementally
+
+    ## Expand the command argument
+    cmd_arg = ast.arguments[0]
+    exp_state = expand.ExpansionState(variables)
+    ## TODO: Catch exceptions around here
+    expanded_cmd_arg = expand.expand_arg(cmd_arg, exp_state)
+    cmd_str = string_of_arg(expanded_cmd_arg)
+    logging.debug(f'Expanded command argument: {expanded_cmd_arg} (str: "{cmd_str}")')
+
+    ## TODO: Determine if the ast contains a command substitution and if so
+    ##        run it in the original script.
+    ##       In the future, we should be able to perform stateful expansion too,
+    ##        and properly execute and trace command substitutions.
 
     ## KK 2023-05-26 We need to keep in mind that whenever we execute something
     ##               in the original shell, then we cannot speculate anything
     ##               after it, because we cannot track read-write dependencies
     ##               in the original shell.
+
+    if cmd_str in BASH_PRIMITIVES:
+        return False
+    
     return True
+
+BASH_PRIMITIVES = ["break", 
+                   "continue", 
+                   "return"]
+
+
+safe_cases = {
+        "Pipe": (lambda:
+                 lambda ast_node: safe_default(ast_node)),
+        "Command": (lambda:
+                    lambda ast_node: safe_simple(ast_node)),
+        "And": (lambda:
+                lambda ast_node: safe_default(ast_node)),
+        "Or": (lambda:
+               lambda ast_node: safe_default(ast_node)),
+        "Semi": (lambda:
+                 lambda ast_node: safe_default(ast_node)),
+        "Redir": (lambda:
+                  lambda ast_node: safe_default(ast_node)),
+        "Subshell": (lambda:
+                     lambda ast_node: safe_default(ast_node)),
+        "Background": (lambda:
+                       lambda ast_node: safe_default(ast_node)),
+        "Defun": (lambda:
+                  lambda ast_node: safe_default(ast_node)),
+        "For": (lambda:
+                  lambda ast_node: safe_default(ast_node)),
+        "While": (lambda:
+                  lambda ast_node: safe_default(ast_node)),
+        "Case": (lambda:
+                  lambda ast_node: safe_default(ast_node)),
+        "If": (lambda:
+                  lambda ast_node: safe_default(ast_node))
+        }
+
+def safe_command(command):
+    global safe_cases
+    return ast_match(command, safe_cases)
+
+def safe_simple(node: CommandNode):
+    global BASH_PRIMITIVES
+
+    if (len(node.arguments) <= 0):
+        ## KK 2023-05-30 It is unclear if this is ever reachable
+        return True
+
+    ## We only care about the command itself
+    cmd = expand_arg(node.arguments[0])
+    if (cmd in BASH_PRIMITIVES):
+        return False
+    
+    return True 
+
+## By construction we only expect commands in here,
+##  and we cannot recursively see the other constructs because of the way we handle
+##  backquotes.
+def safe_default(node: Command) -> bool:
+    return False
 

--- a/parallel-orch/analysis.py
+++ b/parallel-orch/analysis.py
@@ -43,7 +43,7 @@ def safe_to_execute(asts: "list[AstNode]", variables: dict) -> bool:
     ast = asts[0]
     assert(isinstance(ast, CommandNode))
     logging.debug(f'Ast in question: {ast}')
-    ## TODO: Expand and check whether the asts contain
+    ## Expand and check whether the asts contain
     ##  a command substitution or a primitive.
     ## If so, then we need to tell the original script to execute the command.
 

--- a/parallel-orch/partial_program_order.py
+++ b/parallel-orch/partial_program_order.py
@@ -260,6 +260,10 @@ class PartialProgramOrder:
         ## we should keep those in the workset but not execute them
         ## until they reach the frontier
         self.stopped = set()
+        ## Commands deemed unsafe from our analysis, that have to be executed
+        ##  in the original shell (e.g., shell primitives)
+        ## Invariant: self.unsafe \subseteq self.stopped
+        self.unsafe = set()
         self.committed_order = []
         self.commit_state = {}
         ## Counts the times a node was (re)executed
@@ -380,7 +384,19 @@ class PartialProgramOrder:
 
     def get_workset(self) -> list:
         return self.workset
+
+    def get_unsafe(self) -> set:
+        return copy.deepcopy(self.unsafe)
     
+    ## Only return the stopped that are not unsafe
+    def get_stopped_safe(self) -> set:
+        return copy.deepcopy(self.stopped.difference(self.unsafe))
+
+    ## When we remove a command from unsafe we always remove from stopped too
+    def remove_from_unsafe(self, node_id: NodeId):
+        self.unsafe.remove(node_id)
+        self.stopped.remove(node_id)
+
     def get_committed(self) -> set:
         return copy.deepcopy(self.committed)
 
@@ -408,11 +424,14 @@ class PartialProgramOrder:
         ## TODO: Add a check that for x, y : NodeIds, x < y iff x is a predecessor to x
         ##       This is necessary due to the `hypothetical_before` method.
 
+        ## Any command in unsafe must also be in stopped
+        valid2 = self.unsafe.issubset(self.stopped)
+
         ## TODO: Fix the checks below because they do not work currently
         ## TODO: Check that committed is prefix closed w.r.t partial order
         # self.all_frontier_nodes_after_committed_nodes()
         # self.frontier_and_committed_intersect()
-        return valid1
+        return valid1 and valid2
 
     ## Checks if loop nodes are all valid, i.e., that there are no loop nodes handled like normal ones,
     ##   e.g., in workset, frontier etc
@@ -685,7 +704,9 @@ class PartialProgramOrder:
 
     def rerun_stopped(self):
         new_stopped = self.stopped.copy()
-        for cmd_id in self.stopped:
+        ## We never remove stopped commands that are unsafe
+        ##  from the stopped set to be reexecuted.
+        for cmd_id in self.get_stopped_safe():
             if cmd_id in self.frontier:
                 self.workset.append(cmd_id)
                 logging.debug(f"Removing {cmd_id} from stopped")
@@ -849,6 +870,7 @@ class PartialProgramOrder:
             ## TODO: Move this to the scheduler.schedule_work() (if we have a loop node waiting for response and we are not unrolled, unroll to create work)
             self.maybe_unroll(node_id)
 
+        assert(self.valid())
 
     def find_outer_loop_sub_partial_order(self, loop_id: int, nodes_subset: "list[NodeId]") -> "list[NodeId]":
         loop_node_ids = []
@@ -1174,7 +1196,20 @@ class PartialProgramOrder:
         is_safe = analysis.safe_to_execute(node.asts, variables)
         if not is_safe:
             logging.debug(f'Command: "{node}" is not safe to execute, sending to the original shell to execute...')
+            
+            ## Keep some state around to determine that this command is not safe to execute.
+            self.stopped.add(node_id)
+            self.unsafe.add(node_id)
+            return
+
             ## TODO: Implement the mechanism that runs the command in the original shell
+            ##
+            ## TODO: Once we receive the wait for this command, we need to respond
+            ##        that it is unsafe, and let the original shell execute it.
+            ## TODO: After we respond to the wait, we need to invalidate all later
+            ##        commands as if they had dependencies with it. In the future,
+            ##        we can be smarter with it. Many unsafe commands will not have
+            ##        other side-effects, so we don't need to invalidate anything after them.
         cmd = node.get_cmd()
         self.executions[node_id] += 1
         if speculate:
@@ -1262,13 +1297,14 @@ class PartialProgramOrder:
 
     def log_partial_program_order_info(self):
         logging.debug(f"=" * 80)
-        logging.debug(f"WORKSET:        {self.get_workset()}")
-        logging.debug(f"COMMITTED:      {self.get_committed_list()}")
-        logging.debug(f"FRONTIER:       {self.get_frontier()}")
-        logging.debug(f"EXECUTING:      {list(self.commands_currently_executing.keys())}")
-        logging.debug(f"STOPPED:        {list(self.stopped)}")
-        logging.debug(f"WAITING:        {sorted(list(self.waiting_to_be_resolved))}")
-        logging.debug(f"TO RESOLVE:     {self.to_be_resolved}")
+        logging.debug(f"WORKSET:          {self.get_workset()}")
+        logging.debug(f"COMMITTED:        {self.get_committed_list()}")
+        logging.debug(f"FRONTIER:         {self.get_frontier()}")
+        logging.debug(f"EXECUTING:        {list(self.commands_currently_executing.keys())}")
+        logging.debug(f"STOPPED:          {list(self.stopped)}")
+        logging.debug(f" of which UNSAFE: {list(self.get_unsafe())}")
+        logging.debug(f"WAITING:          {sorted(list(self.waiting_to_be_resolved))}")
+        logging.debug(f"TO RESOLVE:       {self.to_be_resolved}")
         self.log_rw_sets()
         logging.debug(f"=" * 80)
 

--- a/parallel-orch/partial_program_order.py
+++ b/parallel-orch/partial_program_order.py
@@ -1200,16 +1200,12 @@ class PartialProgramOrder:
             ## Keep some state around to determine that this command is not safe to execute.
             self.stopped.add(node_id)
             self.unsafe.add(node_id)
-            return
-
-            ## TODO: Implement the mechanism that runs the command in the original shell
-            ##
-            ## TODO: Once we receive the wait for this command, we need to respond
-            ##        that it is unsafe, and let the original shell execute it.
             ## TODO: After we respond to the wait, we need to invalidate all later
             ##        commands as if they had dependencies with it. In the future,
             ##        we can be smarter with it. Many unsafe commands will not have
             ##        other side-effects, so we don't need to invalidate anything after them.
+            return
+
         cmd = node.get_cmd()
         self.executions[node_id] += 1
         if speculate:

--- a/parallel-orch/partial_program_order.py
+++ b/parallel-orch/partial_program_order.py
@@ -7,7 +7,7 @@ import analysis
 import executor
 import trace
 
-from shasta.ast_node import AstNode
+from shasta.ast_node import AstNode, CommandNode
 
 class CompletedNodeInfo:
     def __init__(self, exit_code, variable_file, stdout_file):
@@ -157,6 +157,10 @@ class Node:
         self.id = id
         self.cmd = cmd
         self.asts = asts
+        ## There can only be a single AST per node, and this
+        ##  must be a command.
+        assert(len(asts) == 1)
+        assert(isinstance(asts[0], CommandNode))
         self.cmd_no_redir = trace.remove_command_redir(self.cmd)
         self.loop_context = loop_context
         ## Keep track of how many iterations of this loop node we have unrolled
@@ -1165,8 +1169,12 @@ class PartialProgramOrder:
 
     def execute_cmd_core(self, node_id: NodeId, speculate=False):
         node = self.get_node(node_id)
-        ## TODO: Do something with the result of this analysis
-        is_safe = analysis.safe_to_execute(node.asts)
+        ## TODO: Read and pass the actual variables in this
+        variables = {}
+        is_safe = analysis.safe_to_execute(node.asts, variables)
+        if not is_safe:
+            logging.debug(f'Command: "{node}" is not safe to execute, sending to the original shell to execute...')
+            ## TODO: Implement the mechanism that runs the command in the original shell
         cmd = node.get_cmd()
         self.executions[node_id] += 1
         if speculate:

--- a/parallel-orch/scheduler_server.py
+++ b/parallel-orch/scheduler_server.py
@@ -39,6 +39,8 @@ def init():
 def success_response(string):
     return f'OK: {string}\n'
 
+def unsafe_response(string):
+    return f'UNSAFE: {string}\n'
 
 def error_response(string):
     return f'ERROR: {string}\n'
@@ -101,7 +103,11 @@ class Scheduler:
             logging.debug(f'Node: {node_id} found in committed, responding immediately!')
             self.waiting_for_response[node_id] = connection
             self.respond_to_pending_wait(node_id)
-            
+        elif node_id in self.partial_program_order.get_unsafe():
+            logging.debug(f'Node: {node_id} found in unsafe, it must be executed in the original shell!')
+            ## TODO: Make a different response
+            self.waiting_for_response[node_id] = connection
+            self.respond_unsafe_to_pending_wait(node_id)
         else:
             ## Command has not executed yet, so we need to wait for it
             logging.debug(f'Node: {node_id} has not finished execution, waiting for response...')
@@ -118,16 +124,35 @@ class Scheduler:
         except:
             raise Exception(f'Parsing failure for line: {input_cmd}')
 
-    def respond_to_pending_wait(self, node_id: int):
-        assert(node_id in self.waiting_for_response)
-        ## Get the connection that we need to respond to
-        connection = self.waiting_for_response.pop(node_id)
+    def respond_unsafe_to_pending_wait(self, node_id: int):
+        assert(node_id in self.partial_program_order.get_unsafe())
 
+        ## First remove node_id from unsafe and stopped and add to committed
+        ##  since it will be executed immediately in the original shell
+        self.partial_program_order.remove_from_unsafe(node_id)
+        self.partial_program_order.commit_node(node_id)
+
+        response = unsafe_response("")
+
+        ## Send the response
+        self.respond_to_frontend_core(node_id, response)
+
+
+    def respond_to_pending_wait(self, node_id: int):
         ## Get the completed node info
         node = self.partial_program_order.get_node(node_id)
         completed_node_info = node.get_completed_node_info()
-        response = f'{completed_node_info.get_exit_code()} {completed_node_info.get_variable_file()} {completed_node_info.get_stdout_file()}'
-        socket_respond(connection, success_response(response))
+        msg = f'{completed_node_info.get_exit_code()} {completed_node_info.get_variable_file()} {completed_node_info.get_stdout_file()}'
+        response = success_response(msg)
+        ## Send the response
+        self.respond_to_frontend_core(node_id, response)
+
+
+    def respond_to_frontend_core(self, node_id: NodeId, response: str):
+        assert(node_id in self.waiting_for_response)
+        ## Get the connection that we need to respond to
+        connection = self.waiting_for_response.pop(node_id)
+        socket_respond(connection, response)
         connection.close()
 
     def handle_command_exec_complete(self, input_cmd: str):
@@ -175,6 +200,17 @@ class Scheduler:
             logging.error(error_response(f'Error: Unsupported command: {input_cmd}'))
             raise Exception(f'Error: Unsupported command: {input_cmd}')
 
+    def check_unsafe_and_waiting(self):
+        ## If a command is waiting and also deemed to be unsafe, we need to respond
+        waiting_for_response = set(self.waiting_for_response.keys())
+        unsafe = set(self.partial_program_order.get_unsafe())
+        unsafe_and_waiting = unsafe.intersection(waiting_for_response)
+        if len(unsafe_and_waiting) > 0:
+            assert(len(unsafe_and_waiting) == 1)
+            logging.debug(f'Unsafe and waiting for response nodes: {unsafe_and_waiting}')
+            logging.debug(f'Sending responses to them: {unsafe_and_waiting}')
+            unsafe_and_waiting_id = list(unsafe_and_waiting)[0]
+            self.respond_unsafe_to_pending_wait(unsafe_and_waiting_id)
 
     ## This function schedules commands for execution until our capacity is reached
     ##
@@ -182,6 +218,9 @@ class Scheduler:
     ## It is called once per loop iteration, making sure that there is always work happening
     def schedule_work(self):
         self.partial_program_order.schedule_work()
+
+        ## Respond to any waiting nodes that have been deemed to be unsafe
+        self.check_unsafe_and_waiting()
 
     def run(self):
         ## The first command should be the daemon start

--- a/parallel-orch/scheduler_server.py
+++ b/parallel-orch/scheduler_server.py
@@ -105,7 +105,6 @@ class Scheduler:
             self.respond_to_pending_wait(node_id)
         elif node_id in self.partial_program_order.get_unsafe():
             logging.debug(f'Node: {node_id} found in unsafe, it must be executed in the original shell!')
-            ## TODO: Make a different response
             self.waiting_for_response[node_id] = connection
             self.respond_unsafe_to_pending_wait(node_id)
         else:

--- a/parallel-orch/scheduler_server.py
+++ b/parallel-orch/scheduler_server.py
@@ -190,8 +190,9 @@ class Scheduler:
         elif (input_cmd.startswith("Done")):
             
             logging.debug(f'Scheduler server received shutdown message.')
-            assert self.partial_program_order.is_completed(), 'The partial program order was not completed!'
             logging.debug(f'The partial order was successfully completed.')
+            if not self.partial_program_order.is_completed():
+                logging.debug(" |- some nodes were skipped completed.")
             socket_respond(connection, success_response("All finished!"))
             self.partial_program_order.log_committed_cmd_state()
             self.partial_program_order.log_executions()
@@ -238,13 +239,19 @@ class Scheduler:
             # If workset is empty we should end.
             # TODO: ec checks fail for now
         self.socket.close()
-        shutdown()
+        self.shutdown()
 
+    def shutdown(self):
+        ## There may be races since this is called through the signal handling
+        logging.debug("PaSh-Spec scheduler is shutting down...")
+        logging.debug("PaSh-Spec scheduler shut down successfully...")
+        self.terminate_pending_commands()
+        
+    def terminate_pending_commands(self):
+        for _node_id, cmd_info in self.partial_program_order.commands_currently_executing.items():
+            proc, _trace_file, _stdout, _stderr, _variable_file = cmd_info
+            proc.terminate()
 
-def shutdown():
-    ## There may be races since this is called through the signal handling
-    logging.debug("PaSh-Spec scheduler is shutting down...")
-    logging.debug("PaSh-Spec scheduler shut down successfully...")
 
 def main():
     args = init()

--- a/test/test_orch.sh
+++ b/test/test_orch.sh
@@ -339,7 +339,7 @@ if [ "$#" -eq 0 ]; then
     run_test test9_3
     run_test test_stdout
     run_test test_loop
-    # run_test test_break
+    run_test test_break
 else
     for testname in $@
     do


### PR DESCRIPTION
Still WIP and flaky.

Support `break` and `continue` by expanding the command and if determined to be a shell primitive asking the original shell to execute it.

TODOs:
- [X] If a shell primitive is found, inform the frontend
- [x] Commit the changes in PaSh before merging
- [ ] (Later) Mark not safe commands as non-speculated and as if they have dependencies with every other command 
- [ ] (Later) Support skipping nodes in the partial order (due to break)
- [ ] (Later) Catch expansion exceptions and decide what to do with them
- [ ] (Later) Read variables before expanding to make a proper expansion decision
