### PR TITLE
Fix wrong spec

### DIFF
--- a/parallel-orch/node.py
+++ b/parallel-orch/node.py
@@ -291,6 +291,12 @@ class ConcreteNode:
         assert self.state in [NodeState.EXECUTING, NodeState.SPEC_EXECUTING]
         self.exec_ctxt.process.kill()
 
+    def try_reset_to_ready(self):
+        if self.state in [NodeState.READY]:
+            return
+        else:
+            self.reset_to_ready()
+        
     def reset_to_ready(self):
         assert self.state in [NodeState.EXECUTING, NodeState.SPEC_EXECUTING,
                               NodeState.SPECULATED]

--- a/parallel-orch/node.py
+++ b/parallel-orch/node.py
@@ -292,7 +292,7 @@ class ConcreteNode:
         self.exec_ctxt.process.kill()
 
     def try_reset_to_ready(self):
-        if self.state in [NodeState.READY]:
+        if self.state in [NodeState.READY, NodeState.UNSAFE]:
             return
         else:
             self.reset_to_ready()

--- a/parallel-orch/partial_program_order.py
+++ b/parallel-orch/partial_program_order.py
@@ -288,7 +288,7 @@ class PartialProgramOrder:
             self.spec_exec_order.pop(0)
         else:
             for cnid in self.spec_exec_order:
-                self.concrete_nodes[cnid].reset_to_ready()
+                self.concrete_nodes[cnid].try_reset_to_ready()
             self.spec_exec_order = []
 
         if not concrete_node_id in self.concrete_nodes:


### PR DESCRIPTION
When reseting speculated nodes when wrong control flow speculation happens, don't expect nodes to be speculated