### PR TITLE
Fixoom

### DIFF
--- a/parallel-orch/executor.py
+++ b/parallel-orch/executor.py
@@ -14,7 +14,6 @@ def run_assignment_and_return_env_file(assignment: str, pre_execution_env_file: 
     run_script = f'{config.PASH_SPEC_TOP}/parallel-orch/run_assignment.sh'
     args = ["/bin/bash", run_script, assignment, pre_execution_env_file, post_execution_env_file]
     process = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-    print(f'{process.stdout}')
     return post_execution_env_file
 
 def async_run_and_trace_command_return_trace(command, concrete_node_id, execution_id, pre_execution_env_file, speculate_mode=False):

--- a/parallel-orch/executor.py
+++ b/parallel-orch/executor.py
@@ -13,7 +13,8 @@ def run_assignment_and_return_env_file(assignment: str, pre_execution_env_file: 
     logging.debug(f'Running assignment: {assignment} | pre_execution_env_file: {pre_execution_env_file} | post_execution_env_file: {post_execution_env_file}')
     run_script = f'{config.PASH_SPEC_TOP}/parallel-orch/run_assignment.sh'
     args = ["/bin/bash", run_script, assignment, pre_execution_env_file, post_execution_env_file]
-    process = subprocess.run(args, stderr=subprocess.PIPE, text=True)
+    process = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    print(f'{process.stdout}')
     return post_execution_env_file
 
 def async_run_and_trace_command_return_trace(command, concrete_node_id, execution_id, pre_execution_env_file, speculate_mode=False):

--- a/parallel-orch/node.py
+++ b/parallel-orch/node.py
@@ -429,6 +429,7 @@ class ConcreteNode:
             # Exceptions will be handled inside the call so we don't have to worry
             util.kill_process_tree(process.pid, sig=signal.SIGKILL)
 
+        process.wait()
         util.delete_sandbox(self.exec_ctxt.sandbox_dir)
         self.exec_ctxt = None
         self.exec_result = None

--- a/parallel-orch/node.py
+++ b/parallel-orch/node.py
@@ -429,6 +429,7 @@ class ConcreteNode:
             # Exceptions will be handled inside the call so we don't have to worry
             util.kill_process_tree(process.pid, sig=signal.SIGKILL)
 
+        util.delete_sandbox(self.exec_ctxt.sandbox_dir)
         self.exec_ctxt = None
         self.exec_result = None
         if spec_pre_env is not None:
@@ -457,6 +458,7 @@ class ConcreteNode:
         self.gather_fs_actions()
         self.update_loop_list_context()
         executor.commit_workspace(self.exec_ctxt.sandbox_dir)
+        util.delete_sandbox(self.exec_ctxt.sandbox_dir)
         self.state = NodeState.COMMITTED
 
     def finish_spec_execution(self):
@@ -468,6 +470,7 @@ class ConcreteNode:
     def commit_speculated(self):
         assert self.state == NodeState.SPECULATED
         executor.commit_workspace(self.exec_ctxt.sandbox_dir)
+        util.delete_sandbox(self.exec_ctxt.sandbox_dir)
         self.state = NodeState.COMMITTED
 
     def transition_from_stopped_to_executing(self, env_file=None):

--- a/parallel-orch/node.py
+++ b/parallel-orch/node.py
@@ -352,7 +352,7 @@ class ConcreteNode:
         execute_func = executor.async_run_and_trace_command_return_trace
         # Set the execution id
         self.exec_id = util.generate_id()
-        self.exec_ctxt = ExecCtxt(*execute_func(cmd, self.cnid, self.exec_id, env_file))
+        self.exec_ctxt = ExecCtxt(*execute_func(cmd, self.cnid, self.exec_id, env_file, speculate))
 
     def execution_outcome(self) -> Tuple[int, str, str]:
         assert self.exec_result is not None
@@ -369,7 +369,21 @@ class ConcreteNode:
                                                 self.exec_ctxt.post_env_file)
             new_loop_list = get_loop_list_from_env(real_env_path)
             self.loop_list_context = self.loop_list_context.push(new_loop_list)
-        
+
+    def guess_post_env(self):
+        if self.command_unsafe():
+            env_file = self.spec_pre_env
+        elif self.is_committed():
+            env_file = self.exec_ctxt.post_env_file
+        elif self.is_speculated():
+            env_file = util.sandboxed_path(self.exec_ctxt.sandbox_dir,
+                                               self.exec_ctxt.post_env_file)
+        elif self.is_executing():
+            env_file = self.exec_ctxt.pre_env_file
+        else:
+            env_file = self.spec_pre_env
+        assert env_file is not None
+        return env_file
     ##                                      ##
     ##          Transition Functions        ##
     ##                                      ##
@@ -432,10 +446,14 @@ class ConcreteNode:
         self.start_command(env_file, speculate=True)
         self.state = NodeState.SPEC_EXECUTING
 
-    def commit_frontier_execution(self):
-        assert self.state == NodeState.EXECUTING
+    def collect_result(self):
+        assert self.state in [NodeState.EXECUTING, NodeState.SPEC_EXECUTING]
         self.exec_ctxt.process.wait()
         self.exec_result = ExecResult(self.exec_ctxt.process.returncode, self.exec_ctxt.process.pid)
+        return self.exec_result.exit_code == 137
+        
+    def commit_frontier_execution(self):
+        assert self.state == NodeState.EXECUTING
         self.gather_fs_actions()
         self.update_loop_list_context()
         executor.commit_workspace(self.exec_ctxt.sandbox_dir)
@@ -443,8 +461,6 @@ class ConcreteNode:
 
     def finish_spec_execution(self):
         assert self.state == NodeState.SPEC_EXECUTING
-        self.exec_ctxt.process.wait()
-        self.exec_result = ExecResult(self.exec_ctxt.process.returncode, self.exec_ctxt.process.pid)
         self.update_loop_list_context()
         self.gather_fs_actions()
         self.state = NodeState.SPECULATED

--- a/parallel-orch/partial_program_order.py
+++ b/parallel-orch/partial_program_order.py
@@ -243,24 +243,18 @@ class PartialProgramOrder:
         if (abstract_node.is_loop_list_change() and not abstract_node.is_assignment()
             and not prev_node.is_committed() and not prev_node.is_speculated()):
             return None
+        if prev_node.is_unsafe():
+            return None
         prev_loop_list_context = prev_node.loop_list_context
         loop_iters = prev_node_id.loop_iters
         next_concrete_id = None
         last_abstract_node_id = prev_node_id.node_id
-        if prev_node.is_committed() and prev_node.command_unsafe():
-            pre_env_file = prev_node.spec_pre_env
-        elif prev_node.is_committed():
-            pre_env_file = prev_node.exec_ctxt.post_env_file
-        elif prev_node.is_speculated():
-            pre_env_file = util.sandboxed_path(prev_node.exec_ctxt.sandbox_dir,
-                                               prev_node.exec_ctxt.post_env_file)
-        elif prev_node.is_executing():
-            pre_env_file = prev_node.exec_ctxt.pre_env_file
-        else:
-            pre_env_file = prev_node.spec_pre_env
-            assert pre_env_file is not None
-        if len(open(pre_env_file).read()) == 0:
-            raise ValueError(pre_env_file)
+        pre_env_file = prev_node.guess_post_env()
+        try:
+            if len(open(pre_env_file).read()) == 0:
+                raise ValueError(pre_env_file)
+        except FileNotFoundError:
+            breakpoint()
         while True:
             if bb.node_ids[-1] != last_abstract_node_id:
                 i = bb.node_ids.index(last_abstract_node_id)
@@ -317,16 +311,15 @@ class PartialProgramOrder:
         candidate_nodes = self.get_all_hypothetical_previous(concrete_node.cnid)
         for prev_node in reversed(candidate_nodes):
             candidate_concrete_node = self.concrete_nodes[prev_node]
-            if candidate_concrete_node.exec_ctxt is not None:
-                if candidate_concrete_node.is_committed():
-                    return (candidate_concrete_node, candidate_concrete_node.exec_ctxt.post_env_file)
-                elif candidate_concrete_node.is_speculated():
-                    sandbox_dir = candidate_concrete_node.exec_ctxt.sandbox_dir
-                    post_env_path = candidate_concrete_node.exec_ctxt.post_env_file
-                    return (candidate_concrete_node, util.sandboxed_path(sandbox_dir, post_env_path))
-                else:
-                    return (candidate_concrete_node, candidate_concrete_node.exec_ctxt.pre_env_file)
-        return None
+            if candidate_concrete_node.is_committed():
+                return (candidate_concrete_node, candidate_concrete_node.exec_ctxt.post_env_file)
+            elif candidate_concrete_node.is_speculated():
+                sandbox_dir = candidate_concrete_node.exec_ctxt.sandbox_dir
+                post_env_path = candidate_concrete_node.exec_ctxt.post_env_file
+                return (candidate_concrete_node, util.sandboxed_path(sandbox_dir, post_env_path))
+            else:
+                return (candidate_concrete_node, candidate_concrete_node.exec_ctxt.pre_env_file)
+        assert False
 
     # def get_prev_nodes(self, concrete_node_id: ConcreteNodeId) -> "list[ConcreteNodeId]":
     #     return self.exec_order[concrete_node_id][:]
@@ -418,8 +411,6 @@ class PartialProgramOrder:
     def schedule_spec_work(self, concrete_node_id: ConcreteNodeId):
         event_log("schedule_spec")
         concrete_node = self.get_concrete_node(concrete_node_id)
-        starting_env_node, starting_env = self.get_pre_exec_env_of_concrete_node(concrete_node)
-        util.debug_log(f"concrete_node_id: {concrete_node_id}")
         self.adjust_to_be_resolved_dict_entry(concrete_node_id)
         self.get_concrete_node(concrete_node_id).start_spec_executing(concrete_node.spec_pre_env)
 
@@ -444,7 +435,13 @@ class PartialProgramOrder:
                         current_env: str):
         event_log(f"handle_complete {concrete_node_id}")
         node = self.get_concrete_node(concrete_node_id)
-        # TODO: complete the state matching
+        # TODO: make collect_result a state transition and make more states
+        is_killed = node.collect_result()
+        if is_killed:
+            node.reset_to_ready()
+            if has_pending_wait:
+                node.start_executing(current_env)
+            return
         if node.is_executing():
             node.commit_frontier_execution()
             self.current_loop_list = node.loop_list_context
@@ -503,7 +500,7 @@ class PartialProgramOrder:
             abstract_node = self.hsprog.find_node(concrete_node_id.node_id)
             new_concrete_node = ConcreteNode(concrete_node_id, abstract_node, self.current_loop_list)
             new_concrete_node.transition_from_init_to_ready(env_file)
-            if new_concrete_node.command_unsafe() or abstract_node.is_assignment():
+            if new_concrete_node.command_unsafe():
                 new_concrete_node.transition_from_ready_to_unsafe()
             self.concrete_nodes[concrete_node_id] = new_concrete_node
 

--- a/parallel-orch/partial_program_order.py
+++ b/parallel-orch/partial_program_order.py
@@ -287,6 +287,9 @@ class PartialProgramOrder:
                 continue
             else:
                 cnid = ConcreteNodeId(next_node_id, loop_iters)
+                util.debug_log(f'pick {pre_env_file} as pre_env_file')
+                pre_env_file = util.cp_to_ptmpfile(pre_env_file, 'hs_spec_pre_env')
+                util.debug_log(f'copied to {pre_env_file}')
                 self.create_concrete_node(cnid, pre_env_file, prev_loop_list_context)
                 return cnid
                         
@@ -306,20 +309,6 @@ class PartialProgramOrder:
             prev_node = self.spec_exec_order[-1]
             if self.concrete_nodes[next_concrete_id].is_ready():
                 self.schedule_spec_work(next_concrete_id)
-
-    def get_pre_exec_env_of_concrete_node(self, concrete_node: ConcreteNode):
-        candidate_nodes = self.get_all_hypothetical_previous(concrete_node.cnid)
-        for prev_node in reversed(candidate_nodes):
-            candidate_concrete_node = self.concrete_nodes[prev_node]
-            if candidate_concrete_node.is_committed():
-                return (candidate_concrete_node, candidate_concrete_node.exec_ctxt.post_env_file)
-            elif candidate_concrete_node.is_speculated():
-                sandbox_dir = candidate_concrete_node.exec_ctxt.sandbox_dir
-                post_env_path = candidate_concrete_node.exec_ctxt.post_env_file
-                return (candidate_concrete_node, util.sandboxed_path(sandbox_dir, post_env_path))
-            else:
-                return (candidate_concrete_node, candidate_concrete_node.exec_ctxt.pre_env_file)
-        assert False
 
     # def get_prev_nodes(self, concrete_node_id: ConcreteNodeId) -> "list[ConcreteNodeId]":
     #     return self.exec_order[concrete_node_id][:]

--- a/parallel-orch/run_command.sh
+++ b/parallel-orch/run_command.sh
@@ -16,15 +16,6 @@ export EXECUTION_ID=${10?No execution id given}
 ## GL 2023-07-08: Tests seem to pass without it
 source "$PASH_TOP/compiler/orchestrator_runtime/speculative/pash_spec_init_setup.sh"
 
-# if [ "speculate" == "$EXEC_MODE" ]; then
-#     export speculate_flag=1
-# elif [ "standard" == "$EXEC_MODE" ]; then
-#     export speculate_flag=0
-# else
-#     echo "$$: Unknown value ${EXEC_MODE} for execution mode" 1>&2
-#     exit 1
-# fi
-
 # mkdir -p /tmp/pash_spec/a
 # mkdir -p /tmp/pash_spec/b
 # export SANDBOX_DIR="$(mktemp -d /tmp/pash_spec/a/sandbox_XXXXXXX)/"

--- a/parallel-orch/run_command.sh
+++ b/parallel-orch/run_command.sh
@@ -16,6 +16,12 @@ export EXECUTION_ID=${10?No execution id given}
 ## GL 2023-07-08: Tests seem to pass without it
 source "$PASH_TOP/compiler/orchestrator_runtime/speculative/pash_spec_init_setup.sh"
 
+if [ "standard" == "$EXEC_MODE" ]; then
+    echo $$ > /sys/fs/cgroup/frontier/cgroup.procs
+elif [ "speculate" == "$EXEC_MODE" ]; then
+    renice 20 -p $$
+fi
+
 # mkdir -p /tmp/pash_spec/a
 # mkdir -p /tmp/pash_spec/b
 # export SANDBOX_DIR="$(mktemp -d /tmp/pash_spec/a/sandbox_XXXXXXX)/"

--- a/parallel-orch/run_command.sh
+++ b/parallel-orch/run_command.sh
@@ -19,7 +19,7 @@ source "$PASH_TOP/compiler/orchestrator_runtime/speculative/pash_spec_init_setup
 if [ "standard" == "$EXEC_MODE" ]; then
     echo $$ > /sys/fs/cgroup/frontier/cgroup.procs
 elif [ "speculate" == "$EXEC_MODE" ]; then
-    renice 20 -p $$
+    renice 20 -p $$ >/dev/null
 fi
 
 # mkdir -p /tmp/pash_spec/a

--- a/parallel-orch/template_script_to_execute.sh
+++ b/parallel-orch/template_script_to_execute.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+if [ "speculate" == "$EXEC_MODE" ]; then
+    echo 1000 > /proc/$$/oom_score_adj
+fi
 
 # Magic, don't touch without consulting Di
 RUN=$(printf 'source %s; %s\n exit_code=$?; source $RUNTIME_DIR/pash_declare_vars.sh %s; exit $exit_code' "${LATEST_ENV_FILE}" "${CMD_STRING}" "${POST_EXEC_ENV}")

--- a/parallel-orch/util.py
+++ b/parallel-orch/util.py
@@ -41,7 +41,7 @@ def delete_sandbox(sandbox):
     if not sandbox.startswith('/tmp/pash_spec/a'):
         breakpoint()
     assert sandbox.startswith('/tmp/pash_spec/a')
-    shutil.rmtree(os.path.join(sandbox, 'upperdir'))
+    shutil.rmtree(os.path.join(sandbox, 'upperdir'), ignore_errors=True)
 
 def sandboxed_path(sandbox_dir, path):
     return f"{sandbox_dir}/upperdir/{path}"

--- a/parallel-orch/util.py
+++ b/parallel-orch/util.py
@@ -9,6 +9,7 @@ import re
 import psutil
 import signal
 import analysis
+import shutil
 from node import Node, NodeId, LoopStack, HSProg, HSBasicBlock
 from partial_program_order import PartialProgramOrder
 
@@ -23,6 +24,12 @@ def ptempfile(prefix=''):
     os.close(fd)
     return name
 
+def cp_to_ptmpfile(source, prefix=''):
+    fd, name = tempfile.mkstemp(dir=config.PASH_SPEC_TMP_PREFIX, prefix=prefix+'_')
+    os.close(fd)
+    shutil.copy(source, name)
+    return name
+
 def create_sandbox():
     os.makedirs("/tmp/pash_spec/a", exist_ok=True)
     os.makedirs("/tmp/pash_spec/b", exist_ok=True)
@@ -30,9 +37,14 @@ def create_sandbox():
     tdir = tempfile.mkdtemp(dir="/tmp/pash_spec/b", prefix="sandbox_")
     return sdir, tdir
 
+def delete_sandbox(sandbox):
+    if not sandbox.startswith('/tmp/pash_spec/a'):
+        breakpoint()
+    assert sandbox.startswith('/tmp/pash_spec/a')
+    shutil.rmtree(os.path.join(sandbox, 'upperdir'))
+
 def sandboxed_path(sandbox_dir, path):
     return f"{sandbox_dir}/upperdir/{path}"
-
 
 def init_unix_socket(socket_file: str) -> socket.socket:
     server_address = socket_file

--- a/pash-spec.sh
+++ b/pash-spec.sh
@@ -10,7 +10,7 @@ export PASH_TOP=${PASH_TOP:-$PASH_SPEC_TOP/deps/pash}
 
 sudo mkdir -p /sys/fs/cgroup/frontier
 total_mem=$(free | awk '/Mem:/ { print $2 }')
-protected_mem=$(python3 -c "print(int(${total_mem}*0.75))")
+protected_mem=$(python3 -c "print(int(${total_mem}*0.75) << 10)")
 sudo bash -c "echo $protected_mem > /sys/fs/cgroup/frontier/memory.min"
 
 ## Generate a temporary directory to store the workfiles

--- a/pash-spec.sh
+++ b/pash-spec.sh
@@ -8,6 +8,11 @@
 export PASH_SPEC_TOP=${PASH_SPEC_TOP:-$(git rev-parse --show-toplevel --show-superproject-working-tree)}
 export PASH_TOP=${PASH_TOP:-$PASH_SPEC_TOP/deps/pash}
 
+sudo mkdir -p /sys/fs/cgroup/frontier
+total_mem=$(free | awk '/Mem:/ { print $2 }')
+protected_mem=$(python3 -c "print(int(${total_mem}*0.75))")
+sudo bash -c "echo $protected_mem > /sys/fs/cgroup/frontier/memory.min"
+
 ## Generate a temporary directory to store the workfiles
 mkdir -p /tmp/pash_spec
 
@@ -23,3 +28,5 @@ export PASH_SPEC_SCHEDULER_SOCKET="${PASH_SPEC_TMP_PREFIX}/scheduler_socket"
 ## TODO: Replace this with a call to pa.sh (which will start the scheduler on its own).
 # python3 "$PASH_SPEC_TOP/parallel-orch/orch.py" "$@"
 "$PASH_TOP/pa.sh" --speculative "$@"
+
+sudo rmdir /sys/fs/cgroup/frontier


### PR DESCRIPTION
Add unused try directory cleanup reduce memory usage explosion due to tmpfs, and cgroup control to make OOM-killer better behaving. Also add proper handling for killed nodes.

Now pash-spec.sh has `sudo` sub command in it, and will need access to cgroup v2. If running in docker --cgroupns=host is needed as argument to docker container.